### PR TITLE
Update navigation for Cong Ling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@
 # Basic Site Settings
 locale                   : "en-US"
 site_theme               : "default"
-title                    : "Your Name / Site Title"
+title                    : "Cong Ling's Homepage"
 title_separator          : "-"
 name                     : &name "Your Name"
 description              : &description "personal description"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,26 +8,20 @@
 #      Markdown formatted page while the second is generated using JSON.
 
 main:
+  - title: "Biography"
+    url: /biography/
+
+  - title: "Research"
+    url: /research/
+
+  - title: "Research Group"
+    url: /research-group/
+
   - title: "Publications"
     url: /publications/
 
   - title: "Talks"
-    url: /talks/    
+    url: /talks/
 
   - title: "Teaching"
-    url: /teaching/    
-    
-  - title: "Portfolio"
-    url: /portfolio/
-        
-  - title: "Blog Posts"
-    url: /year-archive/
-    
-  - title: "CV"
-    url: /cv/
-    
-  # - title: "CV"
-  #   url: /cv-json/
-    
-  - title: "Guide"
-    url: /markdown/
+    url: /teaching/

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,49 +1,40 @@
 ---
 permalink: /
-title: "Academic Pages is a ready-to-fork GitHub Pages template for academic personal websites"
+title: "Cong Ling's Homepage"
 author_profile: true
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
 
-This is the front page of a website that is powered by the [Academic Pages template](https://github.com/academicpages/academicpages.github.io) and hosted on GitHub pages. [GitHub pages](https://pages.github.com) is a free service in which websites are built and hosted from code and data stored in a GitHub repository, automatically updating when a new commit is made to the repository. This template was forked from the [Minimal Mistakes Jekyll Theme](https://mmistakes.github.io/minimal-mistakes/) created by Michael Rose, and then extended to support the kinds of content that academics have: publications, talks, teaching, a portfolio, blog posts, and a dynamically-generated CV. You can fork [this template](https://github.com/academicpages/academicpages.github.io) right now, modify the configuration and markdown files, add your own PDFs and other content, and have your own site for free, with no ads!
+{% include base_path %}
+{% if site.author.avatar contains '://' %}
+![Cong]({{ site.author.avatar }}){: .alignright width="200" height="300"}
+{% else %}
+![Cong]({{ base_path }}/images/{{ site.author.avatar }}){: .alignright width="200" height="300"}
+{% endif %}
 
-A data-driven personal website
-======
-Like many other Jekyll-based GitHub Pages templates, Academic Pages makes you separate the website's content from its form. The content & metadata of your website are in structured markdown files, while various other files constitute the theme, specifying how to transform that content & metadata into HTML pages. You keep these various markdown (.md), YAML (.yml), HTML, and CSS files in a public GitHub repository. Each time you commit and push an update to the repository, the [GitHub pages](https://pages.github.com/) service creates static HTML pages based on these files, which are hosted on GitHub's servers free of charge.
+**Cong Ling** (凌聪)  
+[Communications and Signal Processing Group](http://www3.imperial.ac.uk/commssigproc)  
+[Department of Electrical and Electronic Engineering](http://www3.imperial.ac.uk/electricalengineering)  
+[Imperial College London](http://www3.imperial.ac.uk/)  
+South Kensington Campus  
+London SW7 2AZ, United Kingdom
 
-Many of the features of dynamic content management systems (like Wordpress) can be achieved in this fashion, using a fraction of the computational resources and with far less vulnerability to hacking and DDoSing. You can also modify the theme to your heart's content without touching the content of your site. If you get to a point where you've broken something in Jekyll/HTML/CSS beyond repair, your markdown files describing your talks, publications, etc. are safe. You can rollback the changes or even delete the repository and start over - just be sure to save the markdown files! Finally, you can also write scripts that process the structured data on the site, such as [this one](https://github.com/academicpages/academicpages.github.io/blob/master/talkmap.ipynb) that analyzes metadata in pages about talks to display [a map of every location you've given a talk](https://academicpages.github.io/talkmap.html).
+Office: 815, EE Building  
+Tel: +44 (0)20 759-46214  
+Fax: +44 (0)20 759-46302  
+Email: [c.ling@imperial.ac.uk](mailto:c.ling@imperial.ac.uk)
 
-Getting started
-======
-1. Register a GitHub account if you don't have one and confirm your e-mail (required!)
-1. Fork [this template](https://github.com/academicpages/academicpages.github.io) by clicking the "Use this template" button in the top right. 
-1. Go to the repository's settings (rightmost item in the tabs that start with "Code", should be below "Unwatch"). Rename the repository "[your GitHub username].github.io", which will also be your website's URL.
-1. Set site-wide configuration and create content & metadata (see below -- also see [this set of diffs](http://archive.is/3TPas) showing what files were changed to set up [an example site](https://getorg-testacct.github.io) for a user with the username "getorg-testacct")
-1. Upload any files (like PDFs, .zip files, etc.) to the files/ directory. They will appear at https://[your GitHub username].github.io/files/example.pdf.  
-1. Check status by going to the repository settings, in the "GitHub pages" section
+[Direction](http://www.imperial.ac.uk/visit/campuses/south-kensington/)
 
-Site-wide configuration
-------
-The main configuration file for the site is in the base directory in [_config.yml](https://github.com/academicpages/academicpages.github.io/blob/master/_config.yml), which defines the content in the sidebars and other site-wide features. You will need to replace the default variables with ones about yourself and your site's github repository. The configuration file for the top menu is in [_data/navigation.yml](https://github.com/academicpages/academicpages.github.io/blob/master/_data/navigation.yml). For example, if you don't have a portfolio or blog posts, you can remove those items from that navigation.yml file to remove them from the header. 
+### Events
 
-Create content & metadata
-------
-For site content, there is one markdown file for each type of content, which are stored in directories like _publications, _talks, _posts, _teaching, or _pages. For example, each talk is a markdown file in the [_talks directory](https://github.com/academicpages/academicpages.github.io/tree/master/_talks). At the top of each markdown file is structured data in YAML about the talk, which the theme will parse to do lots of cool stuff. The same structured data about a talk is used to generate the list of talks on the [Talks page](https://academicpages.github.io/talks), each [individual page](https://academicpages.github.io/talks/2012-03-01-talk-1) for specific talks, the talks section for the [CV page](https://academicpages.github.io/cv), and the [map of places you've given a talk](https://academicpages.github.io/talkmap.html) (if you run this [python file](https://github.com/academicpages/academicpages.github.io/blob/master/talkmap.py) or [Jupyter notebook](https://github.com/academicpages/academicpages.github.io/blob/master/talkmap.ipynb), which creates the HTML for the map based on the contents of the _talks directory).
+- [Lattice Coding & Crypto Meeting](http://malb.io/discrete-subgroup)
+- [NTC Reading group](http://www.commsp.ee.ic.ac.uk/~cling/NTC/ntc.htm)
+- [Workshop on Diophantine approximation and related fields: York 2017](https://www.york.ac.uk/maths/events/2017/workshop-on-diophantine-approximation-and-related/)
+- [Workshop on interactions between number theory and wireless communication: York2016](http://maths.york.ac.uk/www/York2016)
+- [Are lattice codes ready for application in future networks?](https://conferences.telecom-bretagne.eu/data/turbocodes/Symposium2016/Program/booklet_ISTC2016.pdf)
 
-**Markdown generator**
-
-The repository includes [a set of Jupyter notebooks](https://github.com/academicpages/academicpages.github.io/tree/master/markdown_generator
-) that converts a CSV containing structured data about talks or presentations into individual markdown files that will be properly formatted for the Academic Pages template. The sample CSVs in that directory are the ones I used to create my own personal website at stuartgeiger.com. My usual workflow is that I keep a spreadsheet of my publications and talks, then run the code in these notebooks to generate the markdown files, then commit and push them to the GitHub repository.
-
-How to edit your site's GitHub repository
-------
-Many people use a git client to create files on their local computer and then push them to GitHub's servers. If you are not familiar with git, you can directly edit these configuration and markdown files directly in the github.com interface. Navigate to a file (like [this one](https://github.com/academicpages/academicpages.github.io/blob/master/_talks/2012-03-01-talk-1.md) and click the pencil icon in the top right of the content preview (to the right of the "Raw | Blame | History" buttons). You can delete a file by clicking the trashcan icon to the right of the pencil icon. You can also create new files or upload files by navigating to a directory and clicking the "Create new file" or "Upload files" buttons. 
-
-Example: editing a markdown file for a talk
-![Editing a markdown file for a talk](/images/editing-talk.png)
-
-For more info
-------
-More info about configuring Academic Pages can be found in [the guide](https://academicpages.github.io/markdown/), the [growing wiki](https://github.com/academicpages/academicpages.github.io/wiki), and you can always [ask a question on GitHub](https://github.com/academicpages/academicpages.github.io/discussions). The [guides for the Minimal Mistakes theme](https://mmistakes.github.io/minimal-mistakes/docs/configuration/) (which this theme was forked from) might also be helpful.
+**Post-quantum research paper featured as Editor’s pick in _Physical Review A_.**  
+For more details, see [https://journals.aps.org/pra/abstract/10.1103/PhysRevA.103.032433](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.103.032433)

--- a/_pages/biography.md
+++ b/_pages/biography.md
@@ -1,0 +1,7 @@
+---
+permalink: /biography/
+title: "Biography"
+author_profile: true
+---
+
+Content coming soon.

--- a/_pages/research-group.md
+++ b/_pages/research-group.md
@@ -1,0 +1,7 @@
+---
+permalink: /research-group/
+title: "Research Group"
+author_profile: true
+---
+
+Content coming soon.

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,7 @@
+---
+permalink: /research/
+title: "Research"
+author_profile: true
+---
+
+Content coming soon.


### PR DESCRIPTION
## Summary
- set site title to Cong Ling's Homepage
- customize navigation order
- add placeholder pages for Biography, Research and Research Group
- set about page title to match
- replace default homepage text with Cong Ling contact info

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848c9432c18832b96a8e0ebc0b766a3