### PR TITLE
Adjust publication layout for single-line display

### DIFF
--- a/_includes/archive-single-line.html
+++ b/_includes/archive-single-line.html
@@ -1,0 +1,5 @@
+{% include base_path %}
+<li>
+  <a href="{{ base_path }}{{ post.url }}">{{ post.title }}</a>{% if post.venue %}, <i>{{ post.venue }}</i>{% endif %}{% if post.date %}, {{ post.date | date: '%Y' }}{% endif %}
+</li>
+

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -24,14 +24,14 @@ author_profile: true
         <h2>{{ category[1].title }}</h2><hr />
         {% assign title_shown = true %}
       {% endunless %}
-      {% include archive-single-cv.html %}
+      {% include archive-single-line.html %}
     {% endfor %}
     </ul>
   {% endfor %}
 {% else %}
   <ul>
   {% for post in site.publications reversed %}
-    {% include archive-single-cv.html %}
+    {% include archive-single-line.html %}
   {% endfor %}
   </ul>
 {% endif %}


### PR DESCRIPTION
## Summary
- add a new include `archive-single-line.html` for compact publication entries
- display publications on the publications page using the new single-line include

## Testing
- `bundle exec jekyll build` *(fails: bundler not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6848d9637824832bb86b4eb1d78925a5