### PR TITLE
Fix publications layout

### DIFF
--- a/_includes/archive-single-line.html
+++ b/_includes/archive-single-line.html
@@ -1,12 +1,12 @@
 {% include base_path %}
 <li>
+  {% if post.citation %}
+    {{ post.citation | split:'"' | first | strip }} -
+  {% endif %}
   {% if post.paperurl %}
     <a href="{{ post.paperurl }}">{{ post.title }}</a>
   {% else %}
     <a href="{{ base_path }}{{ post.url }}">{{ post.title }}</a>
-  {% endif %}
-  {% if post.citation %}
-    - {{ post.citation | split:'"' | first | strip }}
   {% endif %}{% if post.venue %}, <i>{{ post.venue }}</i>{% endif %}{% if post.date %}, {{ post.date | date: '%Y' }}{% endif %}
 </li>
 

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -15,7 +15,7 @@ author_profile: true
 {% if site.publication_category %}
   {% for category in site.publication_category %}
     {% assign title_shown = false %}
-    <ul>
+    <ul class="pub-list">
     {% for post in site.publications reversed %}
       {% if post.category != category[0] %}
         {% continue %}
@@ -29,7 +29,7 @@ author_profile: true
     </ul>
   {% endfor %}
 {% else %}
-  <ul>
+  <ul class="pub-list">
   {% for post in site.publications reversed %}
     {% include archive-single-line.html %}
   {% endfor %}

--- a/_sass/layout/_archive.scss
+++ b/_sass/layout/_archive.scss
@@ -27,6 +27,11 @@
   }
 }
 
+/* prevent wrapping for publication list */
+.pub-list li {
+  white-space: nowrap;
+}
+
 .archive__subtitle {
   margin: 1.414em 0 0;
   padding-bottom: 0.5em;


### PR DESCRIPTION
## Summary
- add `pub-list` class to publication list containers
- prevent line wrapping in publication entries

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849726a98b0832b9c08ac1c7285012a