### PR TITLE
Fix publication permalinks with date

### DIFF
--- a/_publications/1998-01-01-chaotic-frequency-hopping-sequences.md
+++ b/_publications/1998-01-01-chaotic-frequency-hopping-sequences.md
@@ -2,7 +2,7 @@
 title: "Chaotic frequency hopping sequences"
 collection: publications
 category: manuscripts
-permalink: /publication/chaotic-frequency-hopping-sequences
+permalink: /publication/1998-01-01-chaotic-frequency-hopping-sequences
 date: 1998-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/1999-01-01-a-general-efficient-method-for-chaotic-signal-estimation.md
+++ b/_publications/1999-01-01-a-general-efficient-method-for-chaotic-signal-estimation.md
@@ -2,7 +2,7 @@
 title: "A general efficient method for chaotic signal estimation"
 collection: publications
 category: manuscripts
-permalink: /publication/a-general-efficient-method-for-chaotic-signal-estimation
+permalink: /publication/1999-01-01-a-general-efficient-method-for-chaotic-signal-estimation
 date: 1999-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: ''

--- a/_publications/1999-01-01-data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation.md
+++ b/_publications/1999-01-01-data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation.md
@@ -2,7 +2,7 @@
 title: "Data-aided phase tracking detection of frequency-shifted DPSK signals with baseband frequency-drift compensation"
 collection: publications
 category: manuscripts
-permalink: /publication/data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation
+permalink: /publication/1999-01-01-data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation
 date: 1999-01-01
 venue: 'Electron. Lett.'
 paperurl: ''

--- a/_publications/1999-01-01-on-sova-for-nonbinary-codes.md
+++ b/_publications/1999-01-01-on-sova-for-nonbinary-codes.md
@@ -2,7 +2,7 @@
 title: "On SOVA for nonbinary codes"
 collection: publications
 category: manuscripts
-permalink: /publication/on-sova-for-nonbinary-codes
+permalink: /publication/1999-01-01-on-sova-for-nonbinary-codes
 date: 1999-01-01
 venue: 'IEEE Commun. Lett.'
 paperurl: ''

--- a/_publications/2000-01-01-chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences.md
+++ b/_publications/2000-01-01-chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences.md
@@ -2,7 +2,7 @@
 title: "Chaotic spreading sequences with multiple access performance better than random sequences"
 collection: publications
 category: manuscripts
-permalink: /publication/chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences
+permalink: /publication/2000-01-01-chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences
 date: 2000-01-01
 venue: 'IEEE Trans. CAS-I'
 paperurl: ''

--- a/_publications/2001-01-01-design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences.md
+++ b/_publications/2001-01-01-design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences.md
@@ -2,7 +2,7 @@
 title: "Design and implementation of an FPGA-based generator for chaotic frequency hopping sequences"
 collection: publications
 category: manuscripts
-permalink: /publication/design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences
+permalink: /publication/2001-01-01-design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences
 date: 2001-01-01
 venue: 'IEEE Trans. CAS-I'
 paperurl: ''

--- a/_publications/2001-01-01-family-size-of-orthogonal-oppermann-sequences.md
+++ b/_publications/2001-01-01-family-size-of-orthogonal-oppermann-sequences.md
@@ -2,7 +2,7 @@
 title: "Family size of orthogonal Oppermann sequences"
 collection: publications
 category: manuscripts
-permalink: /publication/family-size-of-orthogonal-oppermann-sequences
+permalink: /publication/2001-01-01-family-size-of-orthogonal-oppermann-sequences
 date: 2001-01-01
 venue: 'Electron. Lett.'
 paperurl: ''

--- a/_publications/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems.md
+++ b/_publications/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems.md
@@ -2,7 +2,7 @@
 title: "Despreading chip waveform design for coherent delay-locked tracking in DS/SS systems"
 collection: publications
 category: conferences
-permalink: /publication/despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems
+permalink: /publication/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems
 date: 2002-01-01
 venue: 'in Proc. ICC’2002'
 paperurl: ''

--- a/_publications/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels.md
+++ b/_publications/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels"
 collection: publications
 category: conferences
-permalink: /publication/linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels
+permalink: /publication/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels
 date: 2002-01-01
 venue: 'in Proc. ICC’2002'
 paperurl: ''

--- a/_publications/2003-01-01-decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels.md
+++ b/_publications/2003-01-01-decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Decision-feedback multiple symbol differential detection of differential space-time modulation in continuously fading channels"
 collection: publications
 category: manuscripts
-permalink: /publication/decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels
+permalink: /publication/2003-01-01-decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels
 date: 2003-01-01
 venue: 'in Proc. ICASSP’03'
 paperurl: ''

--- a/_publications/2003-01-01-multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels.md
+++ b/_publications/2003-01-01-multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Multisampling decision-feedback linear prediction receivers for differential space-time modulation over Rayleigh fast fading channels"
 collection: publications
 category: manuscripts
-permalink: /publication/multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels
+permalink: /publication/2003-01-01-multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels
 date: 2003-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/2003-01-01-noncoherent-sequence-detection-of-differential-space-time-modulation.md
+++ b/_publications/2003-01-01-noncoherent-sequence-detection-of-differential-space-time-modulation.md
@@ -2,7 +2,7 @@
 title: "Noncoherent sequence detection of differential space-time modulation"
 collection: publications
 category: manuscripts
-permalink: /publication/noncoherent-sequence-detection-of-differential-space-time-modulation
+permalink: /publication/2003-01-01-noncoherent-sequence-detection-of-differential-space-time-modulation
 date: 2003-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: ''

--- a/_publications/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels.md
+++ b/_publications/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels.md
@@ -2,7 +2,7 @@
 title: "On Decision-Feedback Detection of Nondiagonal Differential Space-Time Modulation in Temporally Correlated Fading Channels"
 collection: publications
 category: conferences
-permalink: /publication/on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels
+permalink: /publication/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels
 date: 2003-01-01
 venue: 'in Proc. ICC’03'
 paperurl: ''

--- a/_publications/2003-01-01-performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation.md
+++ b/_publications/2003-01-01-performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation.md
@@ -2,7 +2,7 @@
 title: "Performance evaluation for bandlimited DS-CDMA systems based on simplified improved Gaussian approximation"
 collection: publications
 category: manuscripts
-permalink: /publication/performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation
+permalink: /publication/2003-01-01-performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation
 date: 2003-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/2004-01-01-gallager-bounds-for-space-time-codes.md
+++ b/_publications/2004-01-01-gallager-bounds-for-space-time-codes.md
@@ -2,7 +2,7 @@
 title: "Gallager bounds for space-time codes"
 collection: publications
 category: conferences
-permalink: /publication/gallager-bounds-for-space-time-codes
+permalink: /publication/2004-01-01-gallager-bounds-for-space-time-codes
 date: 2004-01-01
 venue: 'IEEE Communication Theory Workshop 2004'
 paperurl: ''

--- a/_publications/2004-01-01-on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading.md
+++ b/_publications/2004-01-01-on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading.md
@@ -2,7 +2,7 @@
 title: "On decision-feedback detection of differential space-time modulation in continuous fading"
 collection: publications
 category: manuscripts
-permalink: /publication/on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading
+permalink: /publication/2004-01-01-on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading
 date: 2004-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication.md
+++ b/_publications/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication.md
@@ -2,7 +2,7 @@
 title: "Differential lattice decoding in noncoherent MIMO communication"
 collection: publications
 category: conferences
-permalink: /publication/differential-lattice-decoding-in-noncoherent-mimo-communication
+permalink: /publication/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication
 date: 2005-01-01
 venue: 'ICC’05'
 paperurl: ''

--- a/_publications/2005-01-01-multiple-antenna-differential-lattice-decoding.md
+++ b/_publications/2005-01-01-multiple-antenna-differential-lattice-decoding.md
@@ -2,7 +2,7 @@
 title: "Multiple-Antenna differential lattice decoding"
 collection: publications
 category: manuscripts
-permalink: /publication/multiple-antenna-differential-lattice-decoding
+permalink: /publication/2005-01-01-multiple-antenna-differential-lattice-decoding
 date: 2005-01-01
 venue: 'IEEE J-SAC'
 paperurl: ''

--- a/_publications/2006-01-01-a-dual-lattice-view-of-v-blast-detection.md
+++ b/_publications/2006-01-01-a-dual-lattice-view-of-v-blast-detection.md
@@ -2,7 +2,7 @@
 title: "A dual-lattice view of V-BLAST detection"
 collection: publications
 category: conferences
-permalink: /publication/a-dual-lattice-view-of-v-blast-detection
+permalink: /publication/2006-01-01-a-dual-lattice-view-of-v-blast-detection
 date: 2006-01-01
 venue: 'IEEE Inform. Theory Workshop'
 paperurl: ''

--- a/_publications/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction.md
+++ b/_publications/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction.md
@@ -2,7 +2,7 @@
 title: "Approximate lattice decoding: Primal versus dual basis reduction"
 collection: publications
 category: conferences
-permalink: /publication/approximate-lattice-decoding-primal-versus-dual-basis-reduction
+permalink: /publication/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction
 date: 2006-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’06'
 paperurl: ''

--- a/_publications/2006-01-01-bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels.md
+++ b/_publications/2006-01-01-bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Bounds on the decoding error probability of binary block codes over noncoherent block AWGN and fading channels"
 collection: publications
 category: manuscripts
-permalink: /publication/bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels
+permalink: /publication/2006-01-01-bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels
 date: 2006-01-01
 venue: 'IEEE Trans. Wireless Commun.'
 paperurl: ''

--- a/_publications/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels.md
+++ b/_publications/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Gallager bounds for space-time codes in quasi-static fading channels"
 collection: publications
 category: conferences
-permalink: /publication/gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels
+permalink: /publication/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels
 date: 2006-01-01
 venue: 'IEEE Inform. Theory Workshop'
 paperurl: ''

--- a/_publications/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications.md
+++ b/_publications/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications.md
@@ -2,7 +2,7 @@
 title: "Towards characterizing the performance of approximate lattice decoding in MIMO communications"
 collection: publications
 category: conferences
-permalink: /publication/towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications
+permalink: /publication/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications
 date: 2006-01-01
 venue: 'Int. Symp. Turbo Codes / Int. ITG Conf. Source Channel Coding’06'
 paperurl: ''

--- a/_publications/2007-01-01-computation-of-the-dual-frame-forward-and-backward-greville-formulas.md
+++ b/_publications/2007-01-01-computation-of-the-dual-frame-forward-and-backward-greville-formulas.md
@@ -2,7 +2,7 @@
 title: "Computation of the dual frame: Forward and backward Greville formulas"
 collection: publications
 category: manuscripts
-permalink: /publication/computation-of-the-dual-frame-forward-and-backward-greville-formulas
+permalink: /publication/2007-01-01-computation-of-the-dual-frame-forward-and-backward-greville-formulas
 date: 2007-01-01
 venue: 'IEEE ICASSP 2007.'
 paperurl: ''

--- a/_publications/2007-01-01-effective-lll-reduction-for-lattice-decoding.md
+++ b/_publications/2007-01-01-effective-lll-reduction-for-lattice-decoding.md
@@ -2,7 +2,7 @@
 title: "Effective LLL reduction for lattice decoding"
 collection: publications
 category: conferences
-permalink: /publication/effective-lll-reduction-for-lattice-decoding
+permalink: /publication/2007-01-01-effective-lll-reduction-for-lattice-decoding
 date: 2007-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’07'
 paperurl: ''

--- a/_publications/2007-01-01-gallager-bounds-for-noncoherent-decoders-in-fading-channels.md
+++ b/_publications/2007-01-01-gallager-bounds-for-noncoherent-decoders-in-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Gallager bounds for noncoherent decoders in fading channels"
 collection: publications
 category: manuscripts
-permalink: /publication/gallager-bounds-for-noncoherent-decoders-in-fading-channels
+permalink: /publication/2007-01-01-gallager-bounds-for-noncoherent-decoders-in-fading-channels
 date: 2007-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: ''

--- a/_publications/2007-01-01-generalized-union-bound-for-space-time-codes.md
+++ b/_publications/2007-01-01-generalized-union-bound-for-space-time-codes.md
@@ -2,7 +2,7 @@
 title: "Generalized union bound for space-time codes"
 collection: publications
 category: manuscripts
-permalink: /publication/generalized-union-bound-for-space-time-codes
+permalink: /publication/2007-01-01-generalized-union-bound-for-space-time-codes
 date: 2007-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/2007-01-01-new-gallager-bounds-in-block-fading-channels.md
+++ b/_publications/2007-01-01-new-gallager-bounds-in-block-fading-channels.md
@@ -2,7 +2,7 @@
 title: "New Gallager bounds in block fading channels"
 collection: publications
 category: manuscripts
-permalink: /publication/new-gallager-bounds-in-block-fading-channels
+permalink: /publication/2007-01-01-new-gallager-bounds-in-block-fading-channels
 date: 2007-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: ''

--- a/_publications/2007-01-01-on-complex-lll-algorithm-for-digital-communications.md
+++ b/_publications/2007-01-01-on-complex-lll-algorithm-for-digital-communications.md
@@ -2,7 +2,7 @@
 title: "On complex LLL algorithm for digital communications"
 collection: publications
 category: manuscripts
-permalink: /publication/on-complex-lll-algorithm-for-digital-communications
+permalink: /publication/2007-01-01-on-complex-lll-algorithm-for-digital-communications
 date: 2007-01-01
 venue: 'LLL+25 Conference'
 paperurl: ''

--- a/_publications/2007-01-01-towards-understanding-weighted-bit-flipping-decoding.md
+++ b/_publications/2007-01-01-towards-understanding-weighted-bit-flipping-decoding.md
@@ -2,7 +2,7 @@
 title: "Towards understanding weighted bit-flipping decoding"
 collection: publications
 category: conferences
-permalink: /publication/towards-understanding-weighted-bit-flipping-decoding
+permalink: /publication/2007-01-01-towards-understanding-weighted-bit-flipping-decoding
 date: 2007-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’07'
 paperurl: ''

--- a/_publications/2008-01-01-a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines.md
+++ b/_publications/2008-01-01-a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines.md
@@ -2,7 +2,7 @@
 title: "A back-iteration method for reconstructing chaotic sequences in finite-precision machines"
 collection: publications
 category: manuscripts
-permalink: /publication/a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines
+permalink: /publication/2008-01-01-a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines
 date: 2008-01-01
 venue: 'Circuits'
 paperurl: ''

--- a/_publications/2008-01-01-computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas.md
+++ b/_publications/2008-01-01-computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas.md
@@ -2,7 +2,7 @@
 title: "Computation of the Para-Pseudo Inverse for Oversampled Filter Banks: Forward and Backward Greville Formulas"
 collection: publications
 category: manuscripts
-permalink: /publication/computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas
+permalink: /publication/2008-01-01-computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas
 date: 2008-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: ''

--- a/_publications/2008-01-01-performance-of-space-time-codes-gallager-bounds-and-weight-enumeration.md
+++ b/_publications/2008-01-01-performance-of-space-time-codes-gallager-bounds-and-weight-enumeration.md
@@ -2,7 +2,7 @@
 title: "Performance of space-time codes: Gallager bounds and weight enumeration"
 collection: publications
 category: manuscripts
-permalink: /publication/performance-of-space-time-codes-gallager-bounds-and-weight-enumeration
+permalink: /publication/2008-01-01-performance-of-space-time-codes-gallager-bounds-and-weight-enumeration
 date: 2008-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: ''

--- a/_publications/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond.md
+++ b/_publications/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond.md
@@ -2,7 +2,7 @@
 title: "A unified view of sorting in lattice reduction: From V-BLAST to LLL and beyond"
 collection: publications
 category: conferences
-permalink: /publication/a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond
+permalink: /publication/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond
 date: 2009-01-01
 venue: 'IEEE Inform. Theory Workshop 2009'
 paperurl: ''

--- a/_publications/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels.md
+++ b/_publications/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels.md
@@ -2,7 +2,7 @@
 title: "Active physical-layer network coding for cooperative two-way relay channels"
 collection: publications
 category: conferences
-permalink: /publication/active-physical-layer-network-coding-for-cooperative-two-way-relay-channels
+permalink: /publication/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels
 date: 2009-01-01
 venue: 'Second IEEE International Workshop on Wireless Network Coding'
 paperurl: ''

--- a/_publications/2009-01-01-complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection.md
+++ b/_publications/2009-01-01-complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection.md
@@ -2,7 +2,7 @@
 title: "Complex lattice reduction algorithm for low-complexity full-diversity MIMO detection"
 collection: publications
 category: manuscripts
-permalink: /publication/complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection
+permalink: /publication/2009-01-01-complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection
 date: 2009-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: ''

--- a/_publications/2009-01-01-dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection.md
+++ b/_publications/2009-01-01-dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection.md
@@ -2,7 +2,7 @@
 title: "Dual-lattice algorithm and partial lattice reduction for SIC-based MIMO detection"
 collection: publications
 category: manuscripts
-permalink: /publication/dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection
+permalink: /publication/2009-01-01-dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection
 date: 2009-01-01
 venue: 'IEEE J. Sel. Topics on Signal Processing'
 paperurl: ''

--- a/_publications/2009-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding.md
+++ b/_publications/2009-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding.md
@@ -2,7 +2,7 @@
 title: "Multi-dimensional nested lattice quantization for Wyner-Ziv coding"
 collection: publications
 category: conferences
-permalink: /publication/multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding
+permalink: /publication/2009-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding
 date: 2009-01-01
 venue: 'ICC’09'
 paperurl: ''

--- a/_publications/2009-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel.md
+++ b/_publications/2009-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel.md
@@ -2,7 +2,7 @@
 title: "Near-optimal relaying strategy for cooperative broadcast channel"
 collection: publications
 category: conferences
-permalink: /publication/near-optimal-relaying-strategy-for-cooperative-broadcast-channel
+permalink: /publication/2009-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel
 date: 2009-01-01
 venue: 'ICC’09'
 paperurl: ''

--- a/_publications/2009-01-01-new-insights-into-weighted-bit-flipping-decoding-communications.md
+++ b/_publications/2009-01-01-new-insights-into-weighted-bit-flipping-decoding-communications.md
@@ -2,7 +2,7 @@
 title: "New insights into weighted bit-flipping decoding Communications"
 collection: publications
 category: manuscripts
-permalink: /publication/new-insights-into-weighted-bit-flipping-decoding-communications
+permalink: /publication/2009-01-01-new-insights-into-weighted-bit-flipping-decoding-communications
 date: 2009-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices.md
+++ b/_publications/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices.md
@@ -2,7 +2,7 @@
 title: "Statistical restricted isometry property of orthogonal symmetric Toeplitz matrices"
 collection: publications
 category: conferences
-permalink: /publication/statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices
+permalink: /publication/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices
 date: 2009-01-01
 venue: 'IEEE Inform. Theory Workshop 2009'
 paperurl: ''

--- a/_publications/2010-01-01-effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network.md
+++ b/_publications/2010-01-01-effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network.md
@@ -2,7 +2,7 @@
 title: "Effect of correlated Nakagami-m fading on the e-outage channel capacity of the decentralized two-relay network"
 collection: publications
 category: manuscripts
-permalink: /publication/effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network
+permalink: /publication/2010-01-01-effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network
 date: 2010-01-01
 venue: 'IEEE Trans. Wireless. Commun.'
 paperurl: ''

--- a/_publications/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding.md
+++ b/_publications/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding.md
@@ -2,7 +2,7 @@
 title: "Randomized lattice decoding: Bridging the gap between lattice reduction and sphere decoding"
 collection: publications
 category: conferences
-permalink: /publication/randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding
+permalink: /publication/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding
 date: 2010-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’10'
 paperurl: ''

--- a/_publications/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm.md
+++ b/_publications/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm.md
@@ -2,7 +2,7 @@
 title: "Relay-aided interference alignment: Feasibility conditions and algorithm"
 collection: publications
 category: conferences
-permalink: /publication/relay-aided-interference-alignment-feasibility-conditions-and-algorithm
+permalink: /publication/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm
 date: 2010-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’10'
 paperurl: ''

--- a/_publications/2010-01-01-uwb-portable-printed-monopole-array-design-for-mimo-communications.md
+++ b/_publications/2010-01-01-uwb-portable-printed-monopole-array-design-for-mimo-communications.md
@@ -2,7 +2,7 @@
 title: "UWB portable printed monopole array design for MIMO communications"
 collection: publications
 category: manuscripts
-permalink: /publication/uwb-portable-printed-monopole-array-design-for-mimo-communications
+permalink: /publication/2010-01-01-uwb-portable-printed-monopole-array-design-for-mimo-communications
 date: 2010-01-01
 venue: 'Microwave and Optical Technology Letters'
 paperurl: ''

--- a/_publications/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel.md
+++ b/_publications/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel.md
@@ -2,7 +2,7 @@
 title: "Achievable rates for lattice coding over the Gaussian wiretap channel"
 collection: publications
 category: conferences
-permalink: /publication/achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel
+permalink: /publication/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel
 date: 2011-01-01
 venue: 'ICC 2011 Physical Layer Security Workshop.'
 paperurl: ''

--- a/_publications/2011-01-01-decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding.md
+++ b/_publications/2011-01-01-decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding.md
@@ -2,7 +2,7 @@
 title: "Decoding by sampling: A randomized lattice algorithm for bounded-distance decoding"
 collection: publications
 category: manuscripts
-permalink: /publication/decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding
+permalink: /publication/2011-01-01-decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding
 date: 2011-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1003.0064'

--- a/_publications/2011-01-01-deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay.md
+++ b/_publications/2011-01-01-deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay.md
@@ -2,7 +2,7 @@
 title: "Deterministic compressed-sensing matrices: Where Toeplitz meets Golay"
 collection: publications
 category: manuscripts
-permalink: /publication/deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay
+permalink: /publication/2011-01-01-deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay
 date: 2011-01-01
 venue: 'IEEE ICASSP 2011'
 paperurl: ''

--- a/_publications/2011-01-01-feasibility-condition-for-interference-alignment-with-diversity.md
+++ b/_publications/2011-01-01-feasibility-condition-for-interference-alignment-with-diversity.md
@@ -2,7 +2,7 @@
 title: "Feasibility condition for interference alignment with diversity"
 collection: publications
 category: manuscripts
-permalink: /publication/feasibility-condition-for-interference-alignment-with-diversity
+permalink: /publication/2011-01-01-feasibility-condition-for-interference-alignment-with-diversity
 date: 2011-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: ''

--- a/_publications/2011-01-01-generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications.md
+++ b/_publications/2011-01-01-generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications.md
@@ -2,7 +2,7 @@
 title: "Generalized sequential slotted amplify and forward strategy in cooperative communications"
 collection: publications
 category: manuscripts
-permalink: /publication/generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications
+permalink: /publication/2011-01-01-generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications
 date: 2011-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: ''

--- a/_publications/2011-01-01-greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems.md
+++ b/_publications/2011-01-01-greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems.md
@@ -2,7 +2,7 @@
 title: "Greedy user selection using a lattice reduction updating method for multiuser MIMO systems"
 collection: publications
 category: manuscripts
-permalink: /publication/greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems
+permalink: /publication/2011-01-01-greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems
 date: 2011-01-01
 venue: 'IEEE Trans. Vehicular Tech.'
 paperurl: ''

--- a/_publications/2011-01-01-on-the-proximity-factors-of-lattice-reduction-aided-decoding.md
+++ b/_publications/2011-01-01-on-the-proximity-factors-of-lattice-reduction-aided-decoding.md
@@ -2,7 +2,7 @@
 title: "On the proximity factors of lattice reduction-aided decoding"
 collection: publications
 category: manuscripts
-permalink: /publication/on-the-proximity-factors-of-lattice-reduction-aided-decoding
+permalink: /publication/2011-01-01-on-the-proximity-factors-of-lattice-reduction-aided-decoding
 date: 2011-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'http://arxiv.org/abs/1006.1666'

--- a/_publications/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound.md
+++ b/_publications/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound.md
@@ -2,7 +2,7 @@
 title: "Secrecy gain of trellis codes: The other side of the union bound"
 collection: publications
 category: conferences
-permalink: /publication/secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound
+permalink: /publication/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound
 date: 2011-01-01
 venue: 'ITW 2011'
 paperurl: ''

--- a/_publications/2012-01-01-a-construction-of-lattices-from-polar-codes.md
+++ b/_publications/2012-01-01-a-construction-of-lattices-from-polar-codes.md
@@ -2,7 +2,7 @@
 title: "A construction of lattices from polar codes"
 collection: publications
 category: conferences
-permalink: /publication/a-construction-of-lattices-from-polar-codes
+permalink: /publication/2012-01-01-a-construction-of-lattices-from-polar-codes
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'
 paperurl: ''

--- a/_publications/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel.md
+++ b/_publications/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel.md
@@ -2,7 +2,7 @@
 title: "Analysis of lattice codes for the many-to-one interference channel"
 collection: publications
 category: conferences
-permalink: /publication/analysis-of-lattice-codes-for-the-many-to-one-interference-channel
+permalink: /publication/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'
 paperurl: ''

--- a/_publications/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding.md
+++ b/_publications/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding.md
@@ -2,7 +2,7 @@
 title: "Derandomized sampling algorithm for lattice decoding"
 collection: publications
 category: conferences
-permalink: /publication/derandomized-sampling-algorithm-for-lattice-decoding
+permalink: /publication/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'
 paperurl: ''

--- a/_publications/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing.md
+++ b/_publications/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing.md
@@ -2,7 +2,7 @@
 title: "Golay meets Hadamard: Golay-paired Hadamard matrices for fast compressed sensing"
 collection: publications
 category: conferences
-permalink: /publication/golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing
+permalink: /publication/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'
 paperurl: ''

--- a/_publications/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel.md
+++ b/_publications/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel.md
@@ -2,7 +2,7 @@
 title: "Lattice codes achieving strong secrecy over the mod-L Gaussian channel"
 collection: publications
 category: conferences
-permalink: /publication/lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel
+permalink: /publication/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel
 date: 2012-01-01
 venue: 'ISIT 2012.'
 paperurl: ''

--- a/_publications/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging.md
+++ b/_publications/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging.md
@@ -2,7 +2,7 @@
 title: "Novel Toeptlitz sensing matrices for compressive radar imaging"
 collection: publications
 category: conferences
-permalink: /publication/novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging
+permalink: /publication/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging
 date: 2012-01-01
 venue: '1st International Workshop on Compressed Sensing applied to Radar'
 paperurl: ''

--- a/_publications/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast.md
+++ b/_publications/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast.md
@@ -2,7 +2,7 @@
 title: "Proximity factors of lattice reduction-aided precoding for multiantenna broadcast"
 collection: publications
 category: conferences
-permalink: /publication/proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast
+permalink: /publication/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast
 date: 2012-01-01
 venue: 'ISIT 2012.'
 paperurl: ''

--- a/_publications/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling.md
+++ b/_publications/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling.md
@@ -2,7 +2,7 @@
 title: "Reliable sub-Nyquist wideband spectrum sensing based on randomised sampling"
 collection: publications
 category: conferences
-permalink: /publication/reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling
+permalink: /publication/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling
 date: 2012-01-01
 venue: '1st International Workshop on Compressed Sensing applied to Radar'
 paperurl: ''

--- a/_publications/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm.md
+++ b/_publications/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm.md
@@ -2,7 +2,7 @@
 title: "The flatness factor in lattice network coding: Design criterion and decoding algorithm"
 collection: publications
 category: conferences
-permalink: /publication/the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm
+permalink: /publication/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm
 date: 2012-01-01
 venue: 'International Zurich Seminar on Communications 2012'
 paperurl: ''

--- a/_publications/2012-01-01-wyner-ziv-coding-based-on-multi-dimensional-nested-lattices.md
+++ b/_publications/2012-01-01-wyner-ziv-coding-based-on-multi-dimensional-nested-lattices.md
@@ -2,7 +2,7 @@
 title: "Wyner-Ziv coding based on multi-dimensional nested lattices"
 collection: publications
 category: manuscripts
-permalink: /publication/wyner-ziv-coding-based-on-multi-dimensional-nested-lattices
+permalink: /publication/2012-01-01-wyner-ziv-coding-based-on-multi-dimensional-nested-lattices
 date: 2012-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'http://arxiv.org/abs/1111.1347'

--- a/_publications/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution.md
+++ b/_publications/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution.md
@@ -2,7 +2,7 @@
 title: "Achieving the AWGN channel capacity with lattice Gaussian distribution"
 collection: publications
 category: conferences
-permalink: /publication/achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution
+permalink: /publication/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution
 date: 2013-01-01
 venue: 'ISIT 2013.'
 paperurl: ''

--- a/_publications/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel.md
+++ b/_publications/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel.md
@@ -2,7 +2,7 @@
 title: "Barnes-Wall lattices for symmetric interference channel"
 collection: publications
 category: conferences
-permalink: /publication/barnes-wall-lattices-for-symmetric-interference-channel
+permalink: /publication/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel
 date: 2013-01-01
 venue: 'ISIT 2013.'
 paperurl: ''

--- a/_publications/2013-01-01-convolutional-compressed-sensing-using-deterministic-sequences.md
+++ b/_publications/2013-01-01-convolutional-compressed-sensing-using-deterministic-sequences.md
@@ -2,7 +2,7 @@
 title: "Convolutional compressed sensing using deterministic sequences"
 collection: publications
 category: manuscripts
-permalink: /publication/convolutional-compressed-sensing-using-deterministic-sequences
+permalink: /publication/2013-01-01-convolutional-compressed-sensing-using-deterministic-sequences
 date: 2013-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'http://arxiv.org/abs/1210.7506'

--- a/_publications/2013-01-01-decoding-by-embedding-correct-decoding-radius-and-dmt-optimality.md
+++ b/_publications/2013-01-01-decoding-by-embedding-correct-decoding-radius-and-dmt-optimality.md
@@ -2,7 +2,7 @@
 title: "Decoding by embedding: Correct decoding radius and DMT optimality"
 collection: publications
 category: manuscripts
-permalink: /publication/decoding-by-embedding-correct-decoding-radius-and-dmt-optimality
+permalink: /publication/2013-01-01-decoding-by-embedding-correct-decoding-radius-and-dmt-optimality
 date: 2013-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1102.2936'

--- a/_publications/2013-01-01-decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding.md
+++ b/_publications/2013-01-01-decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding.md
@@ -2,7 +2,7 @@
 title: "Decoding by sampling-Part II: Derandomization and soft-output decoding"
 collection: publications
 category: manuscripts
-permalink: /publication/decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding
+permalink: /publication/2013-01-01-decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding
 date: 2013-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'http://arxiv.org/abs/1305.5762'

--- a/_publications/2013-01-01-deterministic-sequences-for-compressive-mimo-channel-estimation.md
+++ b/_publications/2013-01-01-deterministic-sequences-for-compressive-mimo-channel-estimation.md
@@ -2,7 +2,7 @@
 title: "Deterministic sequences for compressive MIMO channel estimation"
 collection: publications
 category: manuscripts
-permalink: /publication/deterministic-sequences-for-compressive-mimo-channel-estimation
+permalink: /publication/2013-01-01-deterministic-sequences-for-compressive-mimo-channel-estimation
 date: 2013-01-01
 venue: 'EUSIPCO 2013.'
 paperurl: ''

--- a/_publications/2013-01-01-integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality.md
+++ b/_publications/2013-01-01-integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality.md
@@ -2,7 +2,7 @@
 title: "Integration of GPS with a WiFi high accuracy ranging functionality"
 collection: publications
 category: manuscripts
-permalink: /publication/integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality
+permalink: /publication/2013-01-01-integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality
 date: 2013-01-01
 venue: 'Geo-spatial Information Science'
 paperurl: ''

--- a/_publications/2013-01-01-lattice-quantization-noise-revisited.md
+++ b/_publications/2013-01-01-lattice-quantization-noise-revisited.md
@@ -2,7 +2,7 @@
 title: "Lattice quantization noise revisited"
 collection: publications
 category: conferences
-permalink: /publication/lattice-quantization-noise-revisited
+permalink: /publication/2013-01-01-lattice-quantization-noise-revisited
 date: 2013-01-01
 venue: 'IEEE Inform. Theory Workshop 2013.'
 paperurl: ''

--- a/_publications/2013-01-01-polar-lattices-where-arikan-meets-forney.md
+++ b/_publications/2013-01-01-polar-lattices-where-arikan-meets-forney.md
@@ -2,7 +2,7 @@
 title: "Polar lattices: Where Arikan meets Forney"
 collection: publications
 category: conferences
-permalink: /publication/polar-lattices-where-arikan-meets-forney
+permalink: /publication/2013-01-01-polar-lattices-where-arikan-meets-forney
 date: 2013-01-01
 venue: 'ISIT 2013.'
 paperurl: ''

--- a/_publications/2013-01-01-reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications.md
+++ b/_publications/2013-01-01-reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications.md
@@ -2,7 +2,7 @@
 title: "Reduced and fixed-complexity variants of the LLL algorithm for communications"
 collection: publications
 category: manuscripts
-permalink: /publication/reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications
+permalink: /publication/2013-01-01-reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications
 date: 2013-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'http://arxiv.org/abs/1006.1661'

--- a/_publications/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing.md
+++ b/_publications/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing.md
@@ -2,7 +2,7 @@
 title: "Secret key generation from Gaussian sources using lattice hashing"
 collection: publications
 category: conferences
-permalink: /publication/secret-key-generation-from-gaussian-sources-using-lattice-hashing
+permalink: /publication/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing
 date: 2013-01-01
 venue: 'ISIT 2013.'
 paperurl: ''

--- a/_publications/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers.md
+++ b/_publications/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers.md
@@ -2,7 +2,7 @@
 title: "Achievable Diversity-Rate Tradeoff of MIMO AF Relaying Systems with MMSE Transceivers"
 collection: publications
 category: conferences
-permalink: /publication/achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers
+permalink: /publication/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers
 date: 2014-01-01
 venue: 'ISIT 2014.'
 paperurl: ''

--- a/_publications/2014-01-01-achieving-awgn-channel-capacity-with-lattice-gaussian-coding.md
+++ b/_publications/2014-01-01-achieving-awgn-channel-capacity-with-lattice-gaussian-coding.md
@@ -2,7 +2,7 @@
 title: "Achieving AWGN channel capacity with lattice Gaussian coding"
 collection: publications
 category: manuscripts
-permalink: /publication/achieving-awgn-channel-capacity-with-lattice-gaussian-coding
+permalink: /publication/2014-01-01-achieving-awgn-channel-capacity-with-lattice-gaussian-coding
 date: 2014-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1302.5906'

--- a/_publications/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin.md
+++ b/_publications/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin.md
@@ -2,7 +2,7 @@
 title: "Lattice Gaussian Coding for Capacity and Secrecy: Two Sides of One Coin"
 collection: publications
 category: conferences
-permalink: /publication/lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin
+permalink: /publication/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin
 date: 2014-01-01
 venue: 'International Zurich Seminar on Communications 2014 (invited paper).'
 paperurl: ''

--- a/_publications/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling.md
+++ b/_publications/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling.md
@@ -2,7 +2,7 @@
 title: "Markov Chain Monte Carlo Algorithms for Lattice Gaussian Sampling"
 collection: publications
 category: conferences
-permalink: /publication/markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling
+permalink: /publication/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling
 date: 2014-01-01
 venue: 'ISIT 2014.'
 paperurl: ''

--- a/_publications/2014-01-01-mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches.md
+++ b/_publications/2014-01-01-mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches.md
@@ -2,7 +2,7 @@
 title: "MIMO Broadcasting for Simultaneous Wireless Information and Power Transfer: Weighted MMSE Approaches"
 collection: publications
 category: conferences
-permalink: /publication/mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches
+permalink: /publication/2014-01-01-mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches
 date: 2014-01-01
 venue: 'Globecom 2014.'
 paperurl: 'http://arxiv.org/abs/1410.4360'

--- a/_publications/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel.md
+++ b/_publications/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel.md
@@ -2,7 +2,7 @@
 title: "Polar Lattices for Strong Secrecy Over the Mod-Lambda Gaussian Wiretap Channel"
 collection: publications
 category: conferences
-permalink: /publication/polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel
+permalink: /publication/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel
 date: 2014-01-01
 venue: 'ISIT 2014.'
 paperurl: ''

--- a/_publications/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices.md
+++ b/_publications/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices.md
@@ -2,7 +2,7 @@
 title: "Secrecy gain, flatness factor, and secrecy-goodness of even unimodular lattices"
 collection: publications
 category: conferences
-permalink: /publication/secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices
+permalink: /publication/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices
 date: 2014-01-01
 venue: 'ISIT 2014.'
 paperurl: ''

--- a/_publications/2014-01-01-semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel.md
+++ b/_publications/2014-01-01-semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel.md
@@ -2,7 +2,7 @@
 title: "Semantically secure lattice codes for the Gaussian wiretap channel"
 collection: publications
 category: manuscripts
-permalink: /publication/semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel
+permalink: /publication/2014-01-01-semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel
 date: 2014-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1210.6673'

--- a/_publications/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message.md
+++ b/_publications/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message.md
@@ -2,7 +2,7 @@
 title: "Superposition Lattice Coding for Gaussian Broadcast Channel with Confidential Message"
 collection: publications
 category: conferences
-permalink: /publication/superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message
+permalink: /publication/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message
 date: 2014-01-01
 venue: 'IEEE Inform. Theory Workshop 2014 (invited paper).'
 paperurl: ''

--- a/_publications/2014-01-01-variable-density-sampling-on-the-dual-lattice.md
+++ b/_publications/2014-01-01-variable-density-sampling-on-the-dual-lattice.md
@@ -2,7 +2,7 @@
 title: "Variable-Density Sampling on the Dual Lattice"
 collection: publications
 category: conferences
-permalink: /publication/variable-density-sampling-on-the-dual-lattice
+permalink: /publication/2014-01-01-variable-density-sampling-on-the-dual-lattice
 date: 2014-01-01
 venue: 'ISIT 2014.'
 paperurl: ''

--- a/_publications/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems.md
+++ b/_publications/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems.md
@@ -2,7 +2,7 @@
 title: "Atomic Norm Denoising-based Channel Estimation for Massive Multiuser MIMO Systems"
 collection: publications
 category: conferences
-permalink: /publication/atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems
+permalink: /publication/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems
 date: 2015-01-01
 venue: 'ICC 2015.'
 paperurl: ''

--- a/_publications/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling.md
+++ b/_publications/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling.md
@@ -2,7 +2,7 @@
 title: "Independent Metropolis-Hastings-Klein Algorithm for Lattice Gaussian Sampling"
 collection: publications
 category: conferences
-permalink: /publication/independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling
+permalink: /publication/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling
 date: 2015-01-01
 venue: 'ISIT 2015.'
 paperurl: 'http://arxiv.org/abs/1501.05757'

--- a/_publications/2015-01-01-modulated-unit-norm-tight-frames-for-compressed-sensing.md
+++ b/_publications/2015-01-01-modulated-unit-norm-tight-frames-for-compressed-sensing.md
@@ -2,7 +2,7 @@
 title: "Modulated Unit-Norm Tight Frames for Compressed Sensing"
 collection: publications
 category: manuscripts
-permalink: /publication/modulated-unit-norm-tight-frames-for-compressed-sensing
+permalink: /publication/2015-01-01-modulated-unit-norm-tight-frames-for-compressed-sensing
 date: 2015-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'http://arxiv.org/abs/1411.7630'

--- a/_publications/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation.md
+++ b/_publications/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation.md
@@ -2,7 +2,7 @@
 title: "Nested Array With Time-Delayers for Target Range and Angle Estimation"
 collection: publications
 category: conferences
-permalink: /publication/nested-array-with-time-delayers-for-target-range-and-angle-estimation
+permalink: /publication/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation
 date: 2015-01-01
 venue: '3rd International Workshop on Compressed Sensing Theory and its Applications to Radar'
 paperurl: ''

--- a/_publications/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes.md
+++ b/_publications/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes.md
@@ -2,7 +2,7 @@
 title: "Achieving Capacity and Security in Wireless Communications With Lattice Codes"
 collection: publications
 category: conferences
-permalink: /publication/achieving-capacity-and-security-in-wireless-communications-with-lattice-codes
+permalink: /publication/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes
 date: 2016-01-01
 venue: 'International Symposium on Turbo Codes 2016.'
 paperurl: ''

--- a/_publications/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel.md
+++ b/_publications/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel.md
@@ -2,7 +2,7 @@
 title: "Algebraic Lattice Codes Achieve the Capacity of the Compound Block-Fading Channel"
 collection: publications
 category: conferences
-permalink: /publication/algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel
+permalink: /publication/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel
 date: 2016-01-01
 venue: 'ISIT 2016.'
 paperurl: 'http://arxiv.org/abs/1603.09263'

--- a/_publications/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel.md
+++ b/_publications/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel.md
@@ -2,7 +2,7 @@
 title: "Algebraic lattices achieve the capacity of the ergodic fading channel"
 collection: publications
 category: conferences
-permalink: /publication/algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel
+permalink: /publication/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel
 date: 2016-01-01
 venue: 'ITW 2016.'
 paperurl: ''

--- a/_publications/2016-01-01-almost-universal-codes-for-fading-wiretap-channels.md
+++ b/_publications/2016-01-01-almost-universal-codes-for-fading-wiretap-channels.md
@@ -2,7 +2,7 @@
 title: "Almost universal codes for fading wiretap channels"
 collection: publications
 category: conferences
-permalink: /publication/almost-universal-codes-for-fading-wiretap-channels
+permalink: /publication/2016-01-01-almost-universal-codes-for-fading-wiretap-channels
 date: 2016-01-01
 venue: 'ISIT 2016.'
 paperurl: 'http://arxiv.org/abs/1601.02391'

--- a/_publications/2016-01-01-artificial-noise-aided-message-authentication-codes-with-information-theoretic-security.md
+++ b/_publications/2016-01-01-artificial-noise-aided-message-authentication-codes-with-information-theoretic-security.md
@@ -2,7 +2,7 @@
 title: "Artificial-Noise-Aided Message Authentication Codes with Information-Theoretic Security"
 collection: publications
 category: manuscripts
-permalink: /publication/artificial-noise-aided-message-authentication-codes-with-information-theoretic-security
+permalink: /publication/2016-01-01-artificial-noise-aided-message-authentication-codes-with-information-theoretic-security
 date: 2016-01-01
 venue: 'IEEE Trans. Inform. Forensics & Security'
 paperurl: 'http://arxiv.org/abs/1511.05357'

--- a/_publications/2016-01-01-artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission.md
+++ b/_publications/2016-01-01-artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission.md
@@ -2,7 +2,7 @@
 title: "Artificial-Noise-Aided Physical Layer Phase Challenge-Response Authentication for Practical OFDM Transmission"
 collection: publications
 category: manuscripts
-permalink: /publication/artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission
+permalink: /publication/2016-01-01-artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission
 date: 2016-01-01
 venue: 'IEEE Trans. Wireless Commun.'
 paperurl: 'http://arxiv.org/abs/1502.07565'

--- a/_publications/2016-01-01-efficient-integer-coefficient-search-for-compute-and-forward.md
+++ b/_publications/2016-01-01-efficient-integer-coefficient-search-for-compute-and-forward.md
@@ -2,7 +2,7 @@
 title: "Efficient Integer Coefficient Search for Compute-and-Forward"
 collection: publications
 category: manuscripts
-permalink: /publication/efficient-integer-coefficient-search-for-compute-and-forward
+permalink: /publication/2016-01-01-efficient-integer-coefficient-search-for-compute-and-forward
 date: 2016-01-01
 venue: 'IEEE Trans. Wireless Commun.'
 paperurl: 'https://arxiv.org/abs/1609.05490'

--- a/_publications/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling.md
+++ b/_publications/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling.md
@@ -2,7 +2,7 @@
 title: "Further Results on Independent Metropolis-Hastings-Klein Sampling"
 collection: publications
 category: conferences
-permalink: /publication/further-results-on-independent-metropolis-hastings-klein-sampling
+permalink: /publication/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling
 date: 2016-01-01
 venue: 'ISIT 2016.'
 paperurl: ''

--- a/_publications/2016-01-01-on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems.md
+++ b/_publications/2016-01-01-on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems.md
@@ -2,7 +2,7 @@
 title: "On the Diversity of Linear Transceivers in MIMO AF Relaying Systems"
 collection: publications
 category: manuscripts
-permalink: /publication/on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems
+permalink: /publication/2016-01-01-on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems
 date: 2016-01-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1403.2081'

--- a/_publications/2016-01-01-polar-codes-and-polar-lattices-for-independent-fading-channels.md
+++ b/_publications/2016-01-01-polar-codes-and-polar-lattices-for-independent-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Polar Codes and Polar Lattices for Independent Fading Channels"
 collection: publications
 category: manuscripts
-permalink: /publication/polar-codes-and-polar-lattices-for-independent-fading-channels
+permalink: /publication/2016-01-01-polar-codes-and-polar-lattices-for-independent-fading-channels
 date: 2016-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'https://arxiv.org/abs/1601.04967'

--- a/_publications/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling.md
+++ b/_publications/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling.md
@@ -2,7 +2,7 @@
 title: "Symmetric Mettropolis-within-Gibbs Algorithm for Lattice Gaussian Sampling"
 collection: publications
 category: conferences
-permalink: /publication/symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling
+permalink: /publication/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling
 date: 2016-01-01
 venue: 'ITW 2016.'
 paperurl: ''

--- a/_publications/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices.md
+++ b/_publications/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices.md
@@ -2,7 +2,7 @@
 title: "Compute-and-Forward over Block-Fading Channels Using Algebraic Lattices"
 collection: publications
 category: conferences
-permalink: /publication/compute-and-forward-over-block-fading-channels-using-algebraic-lattices
+permalink: /publication/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices
 date: 2017-01-01
 venue: 'ISIT 2017.'
 paperurl: 'https://arxiv.org/abs/1702.01422'

--- a/_publications/2017-01-01-coprime-sensing-by-chinese-remaindering-over-rings.md
+++ b/_publications/2017-01-01-coprime-sensing-by-chinese-remaindering-over-rings.md
@@ -2,7 +2,7 @@
 title: "Coprime Sensing by Chinese Remaindering over Rings"
 collection: publications
 category: manuscripts
-permalink: /publication/coprime-sensing-by-chinese-remaindering-over-rings
+permalink: /publication/2017-01-01-coprime-sensing-by-chinese-remaindering-over-rings
 date: 2017-01-01
 venue: 'SAMPTA 2017.'
 paperurl: ''

--- a/_publications/2017-01-01-multilevel-code-construction-for-compound-fading-channels.md
+++ b/_publications/2017-01-01-multilevel-code-construction-for-compound-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Multilevel Code Construction for Compound Fading Channels"
 collection: publications
 category: conferences
-permalink: /publication/multilevel-code-construction-for-compound-fading-channels
+permalink: /publication/2017-01-01-multilevel-code-construction-for-compound-fading-channels
 date: 2017-01-01
 venue: 'ISIT 2017.'
 paperurl: 'https://arxiv.org/abs/1701.08314'

--- a/_publications/2017-09-01-lyu-boosted-kz.md
+++ b/_publications/2017-09-01-lyu-boosted-kz.md
@@ -2,7 +2,7 @@
 title: "Boosted KZ and LLL Algorithms"
 collection: publications
 category: manuscripts
-permalink: /publication/lyu2017boosted
+permalink: /publication/2017-09-01-lyu-boosted-kz
 date: 2017-09-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'https://arxiv.org/abs/1703.03303'

--- a/_publications/2018-01-01-2d-mimo-radar-with-coprime-arrays.md
+++ b/_publications/2018-01-01-2d-mimo-radar-with-coprime-arrays.md
@@ -2,7 +2,7 @@
 title: "2D MIMO Radar with Coprime Arrays"
 collection: publications
 category: manuscripts
-permalink: /publication/2d-mimo-radar-with-coprime-arrays
+permalink: /publication/2018-01-01-2d-mimo-radar-with-coprime-arrays
 date: 2018-01-01
 venue: 'SAM 2018.'
 paperurl: ''

--- a/_publications/2018-01-01-algebraic-polar-lattices-for-fast-fading-channels.md
+++ b/_publications/2018-01-01-algebraic-polar-lattices-for-fast-fading-channels.md
@@ -2,7 +2,7 @@
 title: "Algebraic Polar Lattices for Fast Fading Channels"
 collection: publications
 category: manuscripts
-permalink: /publication/algebraic-polar-lattices-for-fast-fading-channels
+permalink: /publication/2018-01-01-algebraic-polar-lattices-for-fast-fading-channels
 date: 2018-01-01
 venue: 'ISTC 2018.'
 paperurl: ''

--- a/_publications/2018-01-01-atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo.md
+++ b/_publications/2018-01-01-atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo.md
@@ -2,7 +2,7 @@
 title: "Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO"
 collection: publications
 category: manuscripts
-permalink: /publication/atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo
+permalink: /publication/2018-01-01-atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo
 date: 2018-01-01
 venue: 'IEEE Trans. Veh. Tech.'
 paperurl: 'https://arxiv.org/abs/1709.06832'

--- a/_publications/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward.md
+++ b/_publications/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward.md
@@ -2,7 +2,7 @@
 title: "Performance Limits of Lattice Reduction over Imaginary Quadratic Fields with Applications to Compute-and-Forward"
 collection: publications
 category: conferences
-permalink: /publication/performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward
+permalink: /publication/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward
 date: 2018-01-01
 venue: 'ITW 2018.'
 paperurl: 'https://arxiv.org/abs/1806.03113'

--- a/_publications/2018-01-01-shi-heegard-berger.md
+++ b/_publications/2018-01-01-shi-heegard-berger.md
@@ -2,7 +2,7 @@
 title: "Polar Codes and Polar Lattices for the Heegard-Berger Problem"
 collection: publications
 category: manuscripts
-permalink: /publication/shi2018heegard
+permalink: /publication/2018-01-01-shi-heegard-berger
 date: 2018-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'https://arxiv.org/abs/1702.01042'

--- a/_publications/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
+++ b/_publications/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
@@ -2,7 +2,7 @@
 title: "Storage-Repair Bandwidth Trade-off for Wireless Caching with Partial Failure and Broadcast Repair"
 collection: publications
 category: conferences
-permalink: /publication/storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair
+permalink: /publication/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair
 date: 2018-01-01
 venue: 'ITW 2018.'
 paperurl: 'https://arxiv.org/abs/1807.00220'

--- a/_publications/2018-01-15-zheng-polar-cognitive.md
+++ b/_publications/2018-01-15-zheng-polar-cognitive.md
@@ -2,7 +2,7 @@
 title: "Polar Coding for the Cognitive Interference Channel with Confidential Messages"
 collection: publications
 category: manuscripts
-permalink: /publication/zheng2018cognitive
+permalink: /publication/2018-01-15-zheng-polar-cognitive
 date: 2018-01-15
 venue: 'IEEE J. Sel. Areas Commun.'
 paperurl: 'https://arxiv.org/abs/1710.10202'

--- a/_publications/2018-02-01-zhang-atomic-norm.md
+++ b/_publications/2018-02-01-zhang-atomic-norm.md
@@ -2,7 +2,7 @@
 title: "Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO"
 collection: publications
 category: manuscripts
-permalink: /publication/zhang2018atomic
+permalink: /publication/2018-02-01-zhang-atomic-norm
 date: 2018-02-01
 venue: 'IEEE Trans. Veh. Tech.'
 paperurl: 'https://arxiv.org/abs/1709.06832'

--- a/_publications/2018-02-02-wang-ergodicity.md
+++ b/_publications/2018-02-02-wang-ergodicity.md
@@ -2,7 +2,7 @@
 title: "On the Geometric Ergodicity of Metropolis-Hastings Algorithms for Lattice Gaussian Sampling"
 collection: publications
 category: manuscripts
-permalink: /publication/wang2018ergodicity
+permalink: /publication/2018-02-02-wang-ergodicity
 date: 2018-02-02
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1501.05757'

--- a/_publications/2018-03-01-zheng-secure-two-way.md
+++ b/_publications/2018-03-01-zheng-secure-two-way.md
@@ -2,7 +2,7 @@
 title: "Secure Polar Coding for the Two-Way Wiretap Channel"
 collection: publications
 category: manuscripts
-permalink: /publication/zheng2018twoway
+permalink: /publication/2018-03-01-zheng-secure-two-way
 date: 2018-03-01
 venue: 'IEEE Access'
 paperurl: 'https://arxiv.org/abs/1612.00130'

--- a/_publications/2018-03-05-liu-secrecy-capacity.md
+++ b/_publications/2018-03-05-liu-secrecy-capacity.md
@@ -2,7 +2,7 @@
 title: "Achieving Secrecy Capacity of the Gaussian Wiretap Channel with Polar Lattices"
 collection: publications
 category: manuscripts
-permalink: /publication/liu2018secrecy
+permalink: /publication/2018-03-05-liu-secrecy-capacity
 date: 2018-03-05
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'http://arxiv.org/abs/1503.02313'

--- a/_publications/2018-04-01-zhang-uniform-recovery.md
+++ b/_publications/2018-04-01-zhang-uniform-recovery.md
@@ -2,7 +2,7 @@
 title: "Uniform Recovery Bounds for Structured Random Matrices in Corrupted Compressed Sensing"
 collection: publications
 category: manuscripts
-permalink: /publication/zhang2018uniform
+permalink: /publication/2018-04-01-zhang-uniform-recovery
 date: 2018-04-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'https://arxiv.org/abs/1706.09087'

--- a/_publications/2018-11-01-luzzi-wiretap.md
+++ b/_publications/2018-11-01-luzzi-wiretap.md
@@ -2,7 +2,7 @@
 title: "Almost universal codes for MIMO wiretap channels"
 collection: publications
 category: manuscripts
-permalink: /publication/luzzi2018wiretap
+permalink: /publication/2018-11-01-luzzi-wiretap
 date: 2018-11-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'https://arxiv.org/abs/1611.01428'

--- a/_publications/2018-12-01-campello-universal-lattice.md
+++ b/_publications/2018-12-01-campello-universal-lattice.md
@@ -2,7 +2,7 @@
 title: "Universal Lattice Codes for MIMO Channels"
 collection: publications
 category: manuscripts
-permalink: /publication/campello2018mimo
+permalink: /publication/2018-12-01-campello-universal-lattice
 date: 2018-12-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'https://arxiv.org/abs/1603.09263'

--- a/_publications/2019-01-01-lyu-hybrid-vector-perturbation.md
+++ b/_publications/2019-01-01-lyu-hybrid-vector-perturbation.md
@@ -2,7 +2,7 @@
 title: "Hybrid Vector Perturbation Precoding: The Blessing of Approximate Message Passing"
 collection: publications
 category: manuscripts
-permalink: /publication/lyu2019hybrid
+permalink: /publication/2019-01-01-lyu-hybrid-vector-perturbation
 date: 2019-01-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'https://arxiv.org/abs/1710.03791'

--- a/_publications/2019-02-01-liu-polar-lattices.md
+++ b/_publications/2019-02-01-liu-polar-lattices.md
@@ -2,7 +2,7 @@
 title: "Construction of capacity-achieving lattice codes: Polar lattices"
 collection: publications
 category: manuscripts
-permalink: /publication/liu2019polar-lattices
+permalink: /publication/2019-02-01-liu-polar-lattices
 date: 2019-02-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'http://arxiv.org/abs/1411.0187'

--- a/_publications/2019-03-01-campello-awgn-goodness.md
+++ b/_publications/2019-03-01-campello-awgn-goodness.md
@@ -2,7 +2,7 @@
 title: "AWGN-Goodness is Enough: Capacity-Achieving Lattice Codes based on Dithered Probabilistic Shaping"
 collection: publications
 category: manuscripts
-permalink: /publication/campello2019awgn
+permalink: /publication/2019-03-01-campello-awgn-goodness
 date: 2019-03-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'https://arxiv.org/abs/1707.06688'

--- a/_publications/2019-04-01-zheng-polar-interference.md
+++ b/_publications/2019-04-01-zheng-polar-interference.md
@@ -2,7 +2,7 @@
 title: "Polar Coding Strategies for the Interference Channel with Partial-Joint Decoding"
 collection: publications
 category: manuscripts
-permalink: /publication/zheng2019polarinterference
+permalink: /publication/2019-04-01-zheng-polar-interference
 date: 2019-04-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'https://arxiv.org/abs/1608.08742'

--- a/_publications/2019-06-01-li-coprime-sensing.md
+++ b/_publications/2019-06-01-li-coprime-sensing.md
@@ -2,7 +2,7 @@
 title: "Coprime Sensing via Chinese Remaindering over Quadratic Fields"
 collection: publications
 category: manuscripts
-permalink: /publication/li2019coprime
+permalink: /publication/2019-06-01-li-coprime-sensing
 date: 2019-06-01
 venue: 'IEEE Trans. Signal Processing'
 paperurl: 'https://arxiv.org/abs/1808.07505'

--- a/_publications/2019-06-01-wang-lattice-gaussian-sampling.md
+++ b/_publications/2019-06-01-wang-lattice-gaussian-sampling.md
@@ -2,7 +2,7 @@
 title: "Lattice Gaussian Sampling by Markov Chain Monte Carlo: Bounded Distance Decoding and Trapdoor Sampling"
 collection: publications
 category: manuscripts
-permalink: /publication/wang2019lattice
+permalink: /publication/2019-06-01-wang-lattice-gaussian-sampling
 date: 2019-06-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'https://arxiv.org/abs/1704.02673'

--- a/_publications/2019-11-01-lyu-ring-compute-and-forward.md
+++ b/_publications/2019-11-01-lyu-ring-compute-and-forward.md
@@ -2,7 +2,7 @@
 title: "Ring Compute-and-Forward over Block-Fading Channels"
 collection: publications
 category: manuscripts
-permalink: /publication/lyu2019ring
+permalink: /publication/2019-11-01-lyu-ring-compute-and-forward
 date: 2019-11-01
 venue: 'IEEE Trans. Inform. Theory'
 paperurl: 'https://arxiv.org/abs/1805.02073'

--- a/_publications/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels.md
+++ b/_publications/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels.md
@@ -2,7 +2,7 @@
 title: "Coded Computation Against Straggling Channel Decoders in the Cloud for Gaussian Channels"
 collection: publications
 category: conferences
-permalink: /publication/coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels
+permalink: /publication/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels
 date: 2020-01-01
 venue: 'ISIT 2020.'
 paperurl: 'https://arxiv.org/abs/1805.11698'

--- a/_publications/2025-06-08-paper-title-number-5.md
+++ b/_publications/2025-06-08-paper-title-number-5.md
@@ -2,7 +2,7 @@
 title: "Paper Title Number 5, with math $$E=mc^2$$"
 collection: publications
 category: conferences
-permalink: /publication/2024-02-17-paper-title-number-4
+permalink: /publication/2025-06-08-paper-title-number-5
 excerpt: 'This paper is about a famous math equation, $$E=mc^2$$'
 date: 2024-02-17
 venue: 'GitHub Journal of Bugs'

--- a/_publications/2056-06-01-lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling.md
+++ b/_publications/2056-06-01-lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling.md
@@ -2,7 +2,7 @@
 title: "Paper Title Number 4"
 collection: publications
 category: manuscripts
-permalink: /publication/2024-02-17-paper-title-number-4
+permalink: /publication/2056-06-01-lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling
 excerpt: 'This paper is about fixing template issue #693.'
 date: 2056-02-17
 venue: 'GitHub Journal of Bugs'

--- a/_publications/2077-11-01-luzzi-wiretap.md
+++ b/_publications/2077-11-01-luzzi-wiretap.md
@@ -2,7 +2,7 @@
 title: "Multisampling decision-feedback linear prediction receivers for differential space-time modulation over Rayleigh fast fading channels"
 collection: publications
 category: manuscripts
-permalink: /publication/multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels
+permalink: /publication/2077-11-01-luzzi-wiretap
 date: 2088-01-01
 venue: 'IEEE Trans. Commun.'
 paperurl: ''

--- a/_publications/2079-01-01-2d-mimo-radar-with-coprime-arrays.md
+++ b/_publications/2079-01-01-2d-mimo-radar-with-coprime-arrays.md
@@ -2,7 +2,7 @@
 title: "2D MIMO radar with coprime arrays"
 collection: publications
 category: conferences
-permalink: /publication/2d-mimo-radar-with-coprime-arrays
+permalink: /publication/2079-01-01-2d-mimo-radar-with-coprime-arrays
 date: 2079-01-01
 venue: ''
 paperurl: ''

--- a/_publications/2079-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
+++ b/_publications/2079-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
@@ -2,7 +2,7 @@
 title: "Storage-repair bandwidth trade-off for wireless caching with partial failure and broadcast repair"
 collection: publications
 category: conferences
-permalink: /publication/storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair
+permalink: /publication/2079-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair
 date: 2079-01-01
 venue: ''
 paperurl: 'https://ieeexplore.ieee.org/abstract/document/8613401'

--- a/_publications/2079-06-01-lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling.md
+++ b/_publications/2079-06-01-lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling.md
@@ -2,7 +2,7 @@
 title: "Lattice Gaussian sampling by Markov chain Monte Carlo: Bounded distance decoding and trapdoor sampling"
 collection: publications
 category: manuscripts
-permalink: /publication/lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling
+permalink: /publication/2079-06-01-lattice-gaussian-sampling-by-markov-chain-monte-carlo-bounded-distance-decoding-and-trapdoor-sampling
 date: 2079-06-01
 venue: 'IEEE Transactions on Information Theory'
 paperurl: 'https://arxiv.org/abs/1704.02673'

--- a/_publications/2088-11-11-aaaaa.md
+++ b/_publications/2088-11-11-aaaaa.md
@@ -2,7 +2,7 @@
 title: "Construction of capacity-achieving lattice codes: Polar lattices"
 collection: publications
 category: manuscripts
-permalink: /publication/liu2019polar-lattices
+permalink: /publication/2088-11-11-aaaaa
 date: 2038-02-01
 venue: 'IEEE Trans. Commun.'
 paperurl: 'http://arxiv.org/abs/1411.0187'


### PR DESCRIPTION
## Summary
- update all publication permalinks so they match their filenames including the date prefix

## Testing
- `bundle exec jekyll build` *(fails: bundler not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849b2c1356c832b85059ef6989215b4