### PR TITLE
Fix duplicate year display

### DIFF
--- a/_includes/archive-single-line.html
+++ b/_includes/archive-single-line.html
@@ -7,6 +7,6 @@
     <a href="{{ post.paperurl }}">{{ post.title }}</a>
   {% else %}
     <a href="{{ base_path }}{{ post.url }}">{{ post.title }}</a>
-  {% endif %}{% if post.venue %}, <i>{{ post.venue }}</i>{% endif %}{% if post.date %}, {{ post.date | date: '%Y' }}{% endif %}
+  {% endif %}{% if post.venue %}, <i>{{ post.venue }}</i>{% endif %}{% unless post.citation %}{% if post.date %}, {{ post.date | date: '%Y' }}{% endif %}{% endunless %}
 </li>
 


### PR DESCRIPTION
## Summary
- ensure publication list doesn't show year twice

## Testing
- `npm run build:js` *(fails: `uglifyjs: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4a27470832b837bb3ee8b584715