### PR TITLE
Fix publication list display

### DIFF
--- a/_includes/archive-single-line.html
+++ b/_includes/archive-single-line.html
@@ -1,12 +1,13 @@
 {% include base_path %}
 <li>
   {% if post.citation %}
-    {{ post.citation | split:'"' | first | strip }} -
-  {% endif %}
-  {% if post.paperurl %}
-    <a href="{{ post.paperurl }}">{{ post.title }}</a>
+    {{ post.citation }}
   {% else %}
-    <a href="{{ base_path }}{{ post.url }}">{{ post.title }}</a>
+    {% if post.paperurl %}
+      <a href="{{ post.paperurl }}">{{ post.title }}</a>
+    {% else %}
+      <a href="{{ base_path }}{{ post.url }}">{{ post.title }}</a>
     {% endif %}{% if post.venue %}, <i>{{ post.venue }}</i>{% endif %}{% if post.date %}, {{ post.date | date: '%Y' }}{% endif %}
+  {% endif %}
 </li>
 


### PR DESCRIPTION
## Summary
- show the entire citation for each publication listing so page/volume/etc. appear

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*
- `npm run build:js` *(fails: `uglifyjs: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849eef72b4c832bb97228ce2b516f59