### PR TITLE
Simpler publication page

### DIFF
--- a/_pages/publication.md
+++ b/_pages/publication.md
@@ -1,0 +1,27 @@
+---
+layout: archive
+title: "Publication List"
+permalink: /publications/
+author_profile: true
+---
+
+### Journal Articles
+- Chaotic frequency hopping sequences, *IEEE Transactions on communications*, 1998.
+- Data-aided phase tracking detection of frequency-shifted DPSK signals with baseband frequency-drift compensation, *Electron. Lett.*, 1999.
+- On SOVA for nonbinary codes, *IEEE Commun. Lett.*, 1999.
+- Chaotic spreading sequences with multiple access performance better than random sequences, *IEEE Trans. CAS-I*, 2000.
+- Design and realization of an FPGA-based generator for chaotic frequency hopping sequences, *IEEE Transactions on Circuits and Systems I: Fundamental Theory and Applications*, 2001.
+- Family size of orthogonal Oppermann sequences, *Electron. Lett.*, 2001.
+- Performance evaluation for bandlimited DS-CDMA systems based on simplified improved Gaussian approximation, *IEEE Trans. Commun.*, 2003.
+- Multiple-Antenna differential lattice decoding, *IEEE J-SAC*, 2005.
+
+### Conference Papers
+- Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels, in Proc. ICC’2002, New York, 2002.
+- Differential lattice decoding in noncoherent MIMO communication, ICC’05, Seoul, Korea, 2005.
+- Approximate lattice decoding: Primal versus dual basis reduction, IEEE Int. Symp. Inform. Theory’06, Seattle, 2006.
+- Gallager bounds for space-time codes in quasi-static fading channels, IEEE Inform. Theory Workshop, 2006.
+- Towards characterizing the performance of approximate lattice decoding in MIMO communications, Int. Symp. Turbo Codes / Int. ITG Conf. Source Channel Coding’06, Munich, Germany, 2006.
+- Towards understanding weighted bit-flipping decoding, IEEE Int. Symp. Inform. Theory’07, Nice, France, 2007.
+
+### Books
+- None yet.

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -3,6 +3,7 @@ layout: archive
 title: "Publications"
 permalink: /publications/
 author_profile: true
+published: false
 ---
 
 {% if site.author.googlescholar %}


### PR DESCRIPTION
## Summary
- add a new markdown based publication list
- disable the old publications page
- fix permalink and directly list papers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a1b583c8c832b829ae3ec2e11d0d6