### PR TITLE
Update teaching page with course list

### DIFF
--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -7,6 +7,18 @@ author_profile: true
 
 {% include base_path %}
 
+<h2>Courses</h2>
+<p>Current:</p>
+<ul>
+<li>Quantum Information and Post-Quantum Cryptography (jointly with Dr <a href="https://www.imperial.ac.uk/people/f.mintert" target="_blank">Florian Mintert</a>)</li>
+<li><a href="http://www.commsp.ee.ic.ac.uk/~cling/IT/InformationTheory.htm">Information Theory</a></li>
+<li>Probability and Random Processes</li>
+</ul>
+<p>Past:</p>
+<ul>
+<li><a href="http://www.commsp.ee.ic.ac.uk/~cling/Com/Communications.htm">Communication Systems</a></li>
+</ul>
+
 {% for post in site.teaching reversed %}
   {% include archive-single.html %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- add static course listing to Teaching page

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*
- `bundle install` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a28b28470832ba59ac836997928f7