### PR TITLE
Restore manual publication list

### DIFF
--- a/_pages/publication.md
+++ b/_pages/publication.md
@@ -5,34 +5,151 @@ permalink: /publications/
 author_profile: true
 ---
 
-{% if site.author.googlescholar %}
-<div class="wordwrap">You can also find my articles on <a href="{{site.author.googlescholar}}">my Google Scholar profile</a>.</div>
-{% endif %}
+### New
+- Charles Grover, Cong Ling, Roope Vehkalahti, "[Non-Commutative Ring Learning With Errors From Cyclic Algebras](https://eprint.iacr.org/2019/680)", submitted.
+- Jiabo Wang and Cong Ling, "[Polar Sampler: Discrete Gaussian Sampling over the Integers Using Polar Codes](https://eprint.iacr.org/2019/674)", submitted.
+- Shanxiang Lyu, Christian Porter, Cong Ling, "[Lattice Reduction over Imaginary Quadratic Fields](https://arxiv.org/abs/1806.03113)", IEEE Trans. Signal Processing, vol. 68, pp. 6380-6393, Nov. 2020.
+- Ling Liu, Jinwen Shi, and Cong Ling, "[Polar Lattices for Lossy Compression](http://arxiv.org/abs/1501.05683)", IEEE Trans. Inform. Theory, to appear.
+- N. Mital, C. Ling and D. Gunduz, "[Secure Distributed Matrix Computation with Discrete Fourier Transform](https://arxiv.org/abs/2007.03972)", submitted.
+- N. Mital, D. Gunduz and C. Ling, "[Coded Caching in a Multi-Server SystemWith Random Topology](https://arxiv.org/abs/2003.05058)", IEEE Trans. Comm., vol. 68, no. 8, pp. 4620-4631, Aug. 2020.
+- David Joseph, Adam Callison, Cong Ling, Florian Mintert, "[Two quantum Ising algorithms for the Shortest Vector Problem](https://arxiv.org/abs/2006.14057)", Physical Review A, 103, 032433, March 2021.
+- David Joseph, Alexandros Ghionis, Cong Ling, and Florian Mintert, "[Not-so-adiabatic quantum computation for the shortest vector problem](https://arxiv.org/abs/1910.10462)", Physical Review Research, Vol. 2, 013361, 2020.
+- Antonio Campello, Cong Ling and Jean-Claude Belfiore, "[Semantically Secure Lattice Codes for Compound MIMO Channels](https://arxiv.org/abs/1903.09954)", IEEE Trans. Inform. Theory, vol. 66, pp. 1572-1584, Mar 2020.
+**---**
 
-{% include base_path %}
+### Journal Papers
+- Shanxiang Lyu, Antonio Campello, Cong Ling, "[Ring Compute-and-Forward over Block-Fading Channels](https://arxiv.org/abs/1805.02073)", IEEE Trans. Inform. Theory, vol. 65, pp. 6931-6949, Nov 2019.
+- Zheng Wang and Cong Ling, "[Lattice Gaussian Sampling by Markov Chain Monte Carlo: Bounded Distance Decoding and Trapdoor Sampling](https://arxiv.org/abs/1704.02673)", IEEE Trans. Inform. Theory, vol. 65, pp. 3630-3645, June 2019.
+- Conghui Li, Lu Gan and Cong Ling, "Coprime Sensing via Chinese Remaindering over Quadratic Fields, [Part I](https://arxiv.org/abs/1808.07505), [Part II](https://arxiv.org/abs/1808.07511)", IEEE Trans. Signal Processing, vol. 67, pp. 2898-2910, 2911-2922, June 2019.
+- Mengfan Zheng, Cong Ling, Wen Chen, Meixia Tao, "[Polar Coding Strategies for the Interference Channel with Partial-Joint Decoding](https://arxiv.org/abs/1608.08742)", IEEE Trans. Inform. Theory, vol. 65, pp. 1973-1993, Apr. 2019.
+- Antonio Campello, Daniel Dadush, Cong Ling, "[AWGN-Goodness is Enough: Capacity-Achieving Lattice Codes based on Dithered Probabilistic Shaping](https://arxiv.org/abs/1707.06688)", IEEE Trans. Inform. Theory, vol. 65, pp. 1961-1971, Mar. 2019.
+- Ling Liu, Yanfei Yan, Cong Ling and Xiaofu Wu, "[Construction of capacity-achieving lattice codes: Polar lattices](http://arxiv.org/abs/1411.0187)", IEEE Trans. Commun., vol. 67, pp. 915-928, Feb. 2019.
+- Shanxiang Lyu, Cong Ling, "[Hybrid Vector Perturbation Precoding: The Blessing of Approximate Message Passing](https://arxiv.org/abs/1710.03791)", IEEE Trans. Signal Processing, vol. 67, pp. 178-193, Jan. 2019.
+- Antonio Campello, Cong Ling and Jean-Claude Belfiore, "[Universal Lattice Codes for MIMO Channels](https://arxiv.org/abs/1603.09263)", IEEE Trans. Inform. Theory, vol. 64, pp. 7847-7865, Dec. 2018.
+- Laura Luzzi, Roope Vehkalahti, Cong Ling, "[Almost universal codes for MIMO wiretap channels](https://arxiv.org/abs/1611.01428)", IEEE Trans. Inform. Theory, vol. 64, pp. 7218-7241, Nov. 2018.
+- Peng Zhang, Lu Gan, Cong Ling, and Sumei Sun, "[Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO](https://arxiv.org/abs/1709.06832)", IEEE Trans. Veh. Tech., vol. 67, pp. 1389-1403, Feb. 2018.
+- Jinwen Shi, Ling Liu, Deniz Gündüz, Cong Ling, "[Polar Codes and Polar Lattices for the Heegard-Berger Problem](https://arxiv.org/abs/1702.01042)", IEEE Trans. Commun., 2018.
+- Mengfan Zheng, Wen Chen, Cong Ling, "[Polar Coding for the Cognitive Interference Channel with Confidential Messages](https://arxiv.org/abs/1710.10202)", IEEE J. Sel. Areas Commun., 2018.
+- Mengfan Zheng, Meixia Tao, Wen Chen, Cong Ling, "[Secure Polar Coding for the Two-Way Wiretap Channel](https://arxiv.org/abs/1612.00130)", IEEE Access, vol. 6, pp. 21731-21744, Mar. 2018.
+- Ling Liu, Yanfei Yan, Cong Ling and Xiaofu Wu, "[Achieving Secrecy Capacity of the Gaussian Wiretap Channel with Polar Lattices](http://arxiv.org/abs/1503.02313)", IEEE Trans. Inform. Theory, vol. 64, no. 3, pp. 1647-1665, Mar. 2018.
+- Zheng Wang and Cong Ling, "[On the Geometric Ergodicity of Metropolis-Hastings Algorithms for Lattice Gaussian Sampling](http://arxiv.org/abs/1501.05757)", IEEE Trans. Inform. Theory, vol. 64, no. 2, pp. 738-751, Feb. 2018.
+- Peng Zhang, Lu Gan, Cong Ling, and Sumei Sun, "[Uniform Recovery Bounds for Structured Random Matrices in Corrupted Compressed Sensing](https://arxiv.org/abs/1706.09087)", IEEE Trans. Signal Processing, vol. 66, pp. 2086-2097, Apr. 2018.
+- Shanxiang Lyu and Cong Ling, "[Boosted KZ and LLL Algorithms](https://arxiv.org/abs/1703.03303)", IEEE Trans. Signal Processing, vol. 65, pp. 4784-4796, Sept. 2017.
+- William Liu and Cong Ling, "[Efficient Integer Coefficient Search for Compute-and-Forward](https://arxiv.org/abs/1609.05490)", IEEE Trans. Wireless Commun., vol. 15, pp. 8039-8050, Dec. 2016.
+- Ling Liu and Cong Ling, "[Polar Codes and Polar Lattices for Independent Fading Channels](https://arxiv.org/abs/1601.04967)", IEEE Trans. Commun., vol. 64, pp. 4923-4935, Dec. 2016.
+- Xiaofu Wu, Zhen Yan, Cong Ling, Xiang-Gen Xia, "[Artificial-Noise-Aided Physical Layer Phase Challenge-Response Authentication for Practical OFDM Transmission](http://arxiv.org/abs/1502.07565)", IEEE Trans. Wireless Commun., vol. 15, pp. 6611-6625, Oct. 2016.
+- Xiaofu Wu, Zhen Yang, Cong Ling, Xiang-Gen Xia, "[Artificial-Noise-Aided Message Authentication Codes with Information-Theoretic Security](http://arxiv.org/abs/1511.05357)", IEEE Trans. Inform. Forensics & Security, vol. 11, no. 6, pp. 1278-1290, Jan. 2016.
+- Changick Song and Cong Ling, "[On the Diversity of Linear Transceivers in MIMO AF Relaying Systems](http://arxiv.org/abs/1403.2081)", IEEE Trans. Inform. Theory, vol. 62, no. 1, pp. 272-289, Jan. 2016.
+- Peng Zhang, Lu Gan, Sumei Sun, and Cong Ling, "[Modulated Unit-Norm Tight Frames for Compressed Sensing](http://arxiv.org/abs/1411.7630)", IEEE Trans. Signal Processing, vol. 63, no. 15, pp. 3974-3985, Aug. 2015.
+- Cong Ling, Laura Luzzi, Jean-Claude Belfiore, and Damien Stehle, "[Semantically secure lattice codes for the Gaussian wiretap channel](http://arxiv.org/abs/1210.6673)", IEEE Trans. Inform. Theory, vol. 60, no. 10, pp. 6399-6416, Oct. 2014.
+- Cong Ling and Jean-Claude Belfiore, "[Achieving AWGN channel capacity with lattice Gaussian coding](http://arxiv.org/abs/1302.5906)", IEEE Trans. Inform. Theory, vol. 60, no. 10, pp. 5918-5929, Oct. 2014.
+- Zheng Wang, Shuiyin Liu and Cong Ling, "[Decoding by sampling-Part II: Derandomization and soft-output decoding](http://arxiv.org/abs/1305.5762)", IEEE Trans. Commun., vol. 61, no. 11, pp. 4630-4639, Nov. 2013.
+- K Nur, S. Fenga, C. Ling and W. Ochieng, "Integration of GPS with a WiFi high accuracy ranging functionality," Geo-spatial Information Science, vol. 16, no. 3, pp. 155-168, 2013.
+- Laura Luzzi, Damien Stehle, and Cong Ling, "[Decoding by embedding: Correct decoding radius and DMT optimality](http://arxiv.org/abs/1102.2936)", IEEE Trans. Inform. Theory, vol. 59, pp. 1960-2973, May 2013.
+- Cong Ling, Wai Ho Mow, and Nick Howgrave-Graham, "[Reduced and fixed-complexity variants of the LLL algorithm for communications](http://arxiv.org/abs/1006.1661)", IEEE Trans. Commun., vol. 61, pp. 1040-1050, Mar. 2013.
+- Kezhi Li, Lu Gan, and Cong Ling, "[Convolutional compressed sensing using deterministic sequences](http://arxiv.org/abs/1210.7506)", IEEE Trans. Signal Processing, vol. 61, pp. 740-752, Feb. 2013.
+- Cong Ling, Su Gao, and Jean-Claude Belfiore, "[Wyner-Ziv coding based on multi-dimensional nested lattices](http://arxiv.org/abs/1111.1347)", IEEE Trans. Commun., vol. 60, pp. 1328-1335, May 2012.
+- Shuiyin Liu, Cong Ling, and Damien Stehle, "[Decoding by sampling: A randomized lattice algorithm for bounded-distance decoding](http://arxiv.org/abs/1003.0064)", IEEE Trans. Inform. Theory, vol. 57, pp. 5933-5945, Sept. 2011.
+- Cong Ling, "[On the proximity factors of lattice reduction-aided decoding](http://arxiv.org/abs/1006.1666)", IEEE Trans. Signal Processing, vol. 59, pp. 2795-2808, June 2011.
+- Haishi Ning, Cong Ling, and Kin. K. Leung, "Feasibility condition for interference alignment with diversity," IEEE Trans. Inform. Theory, vol. 57, pp. 2902-2912, May 2011.
+- Haishi Ning, Cong Ling, and Kin. K. Leung, "Generalized sequential slotted amplify and forward strategy in cooperative communications," IEEE Trans. Inform. Theory, vol. 57, pp. 1968-1974, Apr. 2011.
+- L. Bai, C. Chen, J. Choi, and C. Ling, "Greedy user selection using a lattice reduction updating method for multiuser MIMO systems," IEEE Trans. Vehicular Tech., vol. 60, pp. 136-147, Jan. 2011.
+- Yifan Chen and Cong Ling, "Effect of correlated Nakagami-m fading on the e-outage channel capacity of the decentralized two-relay network" IEEE Trans. Wireless. Commun., vol. 9, pp. 3607-3612, Dec. 2010.
+- Daniel Valderas, Cong Ling, and Pedro Crespo, "UWB portable printed monopole array design for MIMO communications," Microwave and Optical Technology Letters, vol. 52, pp. 889-895, Apr. 2010.
+- Cong Ling, Wai Ho Mow, and Lu Gan, "[Dual-lattice algorithm and partial lattice reduction for SIC-based MIMO detection](http://arxiv.org/abs/0708.2979)", IEEE J. Sel. Topics on Signal Processing, vol. 3, pp. 975-985, Dec. 2009.
+- Xiaofu Wu, Cong Ling, Ming Jiang, Enyang Xu, Chunming Zhao, and Xiaohu You, "[New insights into weighted bit-flipping decoding Communications](http://arxiv.org/abs/1004.0439)", IEEE Trans. Commun., vol. 57, pp. 2177-2180, Aug. 2009.
+- Ying Hung Gan, Cong Ling, and Wai Ho Mow, "Complex lattice reduction algorithm for low-complexity full-diversity MIMO detection," IEEE Trans. Signal Processing, vol. 57, pp. 2701-2710, July 2009.
+- Lu Gan and Cong Ling, "Computation of the Para-Pseudo Inverse for Oversampled Filter Banks: Forward and Backward Greville Formulas," IEEE Trans. Signal Processing, vol. 56, pp. 5851-5860, Dec. 2008.
+- Cong Ling and Xiaofu Wu, "A back-iteration method for reconstructing chaotic sequences in finite-precision machines," Circuits, Syst., Signal Processing, vol. 27, pp. 883-891, Oct. 2008.
+- Cong Ling, K. H. Li and A. C. Kot, "Performance of space-time codes: Gallager bounds and weight enumeration," IEEE Trans. Inform. Theory, vol. 54, pp. 3592-3610, Aug. 2008.
+- Cong Ling, Xiaofu Wu, K. H. Li, and A. C. Kot, "Gallager bounds for noncoherent decoders in fading channels," IEEE Trans. Inform. Theory, vol. 53, pp. 4605-4614, Dec. 2007.
+- Cong Ling, "[Generalized union bound for space-time codes](http://arxiv.org/abs/0604090)", IEEE Trans. Commun., vol. 55, pp. 90-99, Jan. 2007.
+- Xiaofu Wu, Haige Xiang and Cong Ling, "New Gallager bounds in block fading channels," IEEE Trans. Inform. Theory, vol. 53, pp. 684-694, Feb. 2007.
+- Xiaofu Wu, Haige Xiang, Cong Ling, Xiaohu You, and Shaoqian Li, "Bounds on the decoding error probability of binary block codes over noncoherent block AWGN and fading channels," IEEE Trans. Wireless Commun., vol. 5, pp. 3193-3203, Nov. 2006.
+- Cong Ling, W. H. Mow, K. H. Li and A. C. Kot, "Multiple-Antenna differential lattice decoding," IEEE J-SAC, vol. 23, pp. 1821-1829, Sept. 2005.
+- Cong Ling, K. H. Li and A. C. Kot, "On decision-feedback detection of differential space-time modulation in continuous fading," IEEE Trans. Commun., vol. 52, pp. 1613-1617, Oct. 2004.
+- Cong Ling, K. H. Li and A. C. Kot, "Noncoherent sequence detection of differential space-time modulation," IEEE Trans. Inform. Theory, vol. 49, pp. 2727-2734, Oct. 2003.
+- Cong Ling, K. H. Li, A. C. Kot, and Q. T. Zhang, "Multisampling decision-feedback linear prediction receivers for differential space-time modulation over Rayleigh fast fading channels," IEEE Trans. Commun., vol. 51, pp. 1214-1223, July 2003.
+- Guozhen Zang and Cong Ling, "Performance evaluation for bandlimited DS-CDMA systems based on simplified improved Gaussian approximation," IEEE Trans. Commun., vol. 51, pp. 1204-1213, July 2003.
+- Guozhen Zang and Cong Ling, "Family size of orthogonal Oppermann sequences," Electron. Lett., vol. 37, pp. 631-632, May 2001.
+- Ling Cong and Wu Xiaofu, "[Design and implementation of an FPGA-based generator for chaotic frequency hopping sequences](https://ieeexplore.ieee.org/document/905363)", IEEE Trans. CAS-I, vol. 48, pp. 521-532, May 2001.
+- Ling Cong and Li Shaoqian, "Chaotic spreading sequences with multiple access performance better than random sequences," IEEE Trans. CAS-I, vol. 47, pp. 394-397, Mar. 2000.
+- Ling Cong, Wu Xiaofu and Yi Xiaoxin, "On SOVA for nonbinary codes," IEEE Commun. Lett., vol. 3, pp. 335-337, Dec. 1999.
+- Xiaofu Wu, Cong Ling and Songgeng Sun, "Data-aided phase tracking detection of frequency-shifted DPSK signals with baseband frequency-drift compensation," Electron. Lett., vol. 35, no. 15, pp. 1222-1223, July 1999.
+- Ling Cong, Wu Xiaofu and Sun Songgeng, "A general efficient method for chaotic signal estimation," IEEE Trans. Signal Processing, vol. 47, pp. 1424-1427, May 1999.
+- Ling Cong and Sun Songgeng, "Chaotic frequency hopping sequences," IEEE Trans. Commun., vol. 46, pp. 1433-1437, Nov. 1998.
+**---**
 
-<!-- Automatically list publications -->
-{% if site.publication_category %}
-  {% for category in site.publication_category %}
-    {% assign title_shown = false %}
-    <ul>
-    {% for post in site.publications reversed %}
-      {% if post.category != category[0] %}
-        {% continue %}
-      {% endif %}
-      {% unless title_shown %}
-        <h2>{{ category[1].title }}</h2><hr />
-        {% assign title_shown = true %}
-      {% endunless %}
-      {% include archive-single-line.html %}
-    {% endfor %}
-    </ul>
-  {% endfor %}
-{% else %}
-  <ul>
-  {% for post in site.publications reversed %}
-    {% include archive-single-line.html %}
-  {% endfor %}
-  </ul>
-{% endif %}
+### Conference Papers
+- Jinwen Shi, Cong Ling, Osvaldo Simeone, Jörg Kliewer, "[Coded Computation Against Straggling Channel Decoders in the Cloud for Gaussian Channels](https://arxiv.org/abs/1805.11698)", ISIT 2020.
+- Nitish Mital, Deniz Günduz, Cong Ling, "[Coded caching in a Multi-Server System with Random Topology](https://arxiv.org/abs/1712.00649)", WCNC 2018.
+- Nitish Mital, Katina Kralevska, Deniz Gunduz, Cong Ling, "[Storage-Repair Bandwidth Trade-off for Wireless Caching with Partial Failure and Broadcast Repair](https://arxiv.org/abs/1807.00220)", ITW 2018.
+- Shanxiang Lyu, Christian Porter, Cong Ling, "[Performance Limits of Lattice Reduction over Imaginary Quadratic Fields with Applications to Compute-and-Forward](https://arxiv.org/abs/1806.03113)", ITW 2018.
+- Ling Liu and Cong Ling, "Algebraic Polar Lattices for Fast Fading Channels," ISTC 2018.
+- Conghui Li, Lu Gan and Cong Ling, "2D MIMO Radar with Coprime Arrays," SAM 2018.
+- Antonio Campello, Ling Liu and Cong Ling, "[Multilevel Code Construction for Compound Fading Channels](https://arxiv.org/abs/1701.08314)", ISIT 2017.
+- Shanxiang Lyu, Antonio Campello, Cong Ling and Jean-Claude Belfiore, "[Compute-and-Forward over Block-Fading Channels Using Algebraic Lattices](https://arxiv.org/abs/1702.01422)", ISIT 2017.
+- Conghui Li, Lu Gan and Cong Ling, "Coprime Sensing by Chinese Remaindering over Rings," SAMPTA 2017.
+- Cong Ling, "Achieving Capacity and Security in Wireless Communications With Lattice Codes," International Symposium on Turbo Codes 2016.
+- Zheng Wang and Cong Ling, "Symmetric Mettropolis-within-Gibbs Algorithm for Lattice Gaussian Sampling," ITW 2016.
+- Antonio Campello, Cong Ling and Jean-Claude Belfiore, "Algebraic lattices achieve the capacity of the ergodic fading channel," ITW 2016.
+- Antonio Campello, Cong Ling and Jean-Claude Belfiore, "[Algebraic Lattice Codes Achieve the Capacity of the Compound Block-Fading Channel](http://arxiv.org/abs/1603.09263)", ISIT 2016.
+- L. Luzzi, C. Ling and R. Vehkalahti, "[Almost universal codes for fading wiretap channels](http://arxiv.org/abs/1601.02391)", ISIT 2016.
+- Ling Liu and Cong Ling, "[Polar Codes and Polar Lattices for Independent Fading Channels](http://arxiv.org/abs/1601.04967)", ISIT 2016.
+- Zheng Wang and Cong Ling, "Further Results on Independent Metropolis-Hastings-Klein Sampling," ISIT 2016.
+- Zheng Wang and Cong Ling, "[Independent Metropolis-Hastings-Klein Algorithm for Lattice Gaussian Sampling](http://arxiv.org/abs/1501.05757)", ISIT 2015.
+- Peng Zhang, Lu Gan, Sumei Sun, and Cong Ling, "Atomic Norm Denoising-based Channel Estimation for Massive Multiuser MIMO Systems", ICC 2015.
+- Wen-Qin Wang and Cong Ling, "Nested Array With Time-Delayers for Target Range and Angle Estimation," CoSeRa 2015.
+- Changick Song, Cong Ling, Jaehyun Park, Bruno Clerckx, "[MIMO Broadcasting for Simultaneous Wireless Information and Power Transfer: Weighted MMSE Approaches](http://arxiv.org/abs/1410.4360)", Globecom 2014.
+- Li Chia Choo and Cong Ling, "Superposition Lattice Coding for Gaussian Broadcast Channel with Confidential Message", IEEE Inform. Theory Workshop 2014 (invited paper).
+- Yanfei Yan, Ling Liu and Cong Ling, "Polar Lattices for Strong Secrecy Over the Mod-Lambda Gaussian Wiretap Channel", ISIT 2014.
+- Fuchun Lin, Cong Ling, and Jean-Claude Belfiore, "Secrecy gain, flatness factor, and secrecy-goodness of even unimodular lattices," ISIT 2014.
+- Zheng Wang, Cong Ling, and Guillaume Hanrot, "Markov Chain Monte Carlo Algorithms for Lattice Gaussian Sampling," ISIT 2014.
+- Peng Zhang, Sumei Sun, and Cong Ling, "Variable-Density Sampling on the Dual Lattice," ISIT 2014.
+- Changick Song and Cong Ling, "Achievable Diversity-Rate Tradeoff of MIMO AF Relaying Systems with MMSE Transceivers," ISIT 2014.
+- Cong Ling and Jean-Claude Belfiore, "Lattice Gaussian Coding for Capacity and Secrecy: Two Sides of One Coin," International Zurich Seminar on Communications 2014 (invited paper).
+- Peng Zhang, Lu Gan, Sumei Sun and Cong Ling, "Deterministic sequences for compressive MIMO channel estimation," EUSIPCO 2013.
+- Cong Ling and Lu Gan, "Lattice quantization noise revisited," IEEE Inform. Theory Workshop 2013.
+- Maria Estela, Cong Ling and Jean-Claude Belfiore, "Barnes-Wall lattices for symmetric interference channel," ISIT 2013.
+- Yanfei Yan, Cong Ling and Xiaofu Wu, "Polar lattices: Where Arikan meets Forney," ISIT 2013.
+- Cong Ling, Laura Luzzi and Matthieu Bloch, "Secret key generation from Gaussian sources using lattice hashing," ISIT 2013.
+- Cong Ling and Jean-Claude Belfiore, "Achieving the AWGN channel capacity with lattice Gaussian distribution," ISIT 2013.
+- B. Ahmad, W. Dai, and C. Ling, "Reliable sub-Nyquist wideband spectrum sensing based on randomised sampling," CoSeRa 2012, Bonn, Germany.
+- Lu Gan, Kezhi Li, and Cong Ling, "Novel Toeptlitz sensing matrices for compressive radar imaging," CoSeRa 2012, Bonn, Germany.
+- J.-C. Belfiore and Cong Ling, "The flatness factor in lattice network coding: Design criterion and decoding algorithm," International Zurich Seminar on Communications 2012, invited paper.
+- Yanfei Yan and Cong Ling, "A construction of lattices from polar codes," IEEE Inform. Theory Workshop 2012.
+- Zheng Wang and Cong Ling, "Derandomized sampling algorithm for lattice decoding," IEEE Inform. Theory Workshop 2012.
+- Lu Gan, Kezhi Li, and Cong Ling, "Golay meets Hadamard: Golay-paired Hadamard matrices for fast compressed sensing," IEEE Inform. Theory Workshop 2012.
+- Maria Estela, Laura Luzzi, Cong Ling and Jean-Claude Belfiore, "Analysis of lattice codes for the many-to-one interference channel," IEEE Inform. Theory Workshop 2012.
+- C. Ling, L. Luzzi, and J.-C. Belfiore, "Lattice codes achieving strong secrecy over the mod-L Gaussian channel," ISIT 2012.
+- Suiyin Liu, Cong Ling and Xiaofu Wu, "Proximity factors of lattice reduction-aided precoding for multiantenna broadcast," ISIT 2012.
+- Yanfei Yan, Cong Ling and Jean-Claude Belfiore, "Secrecy gain of trellis codes: The other side of the union bound," ITW 2011, Paraty, Brasil.
+- Cong Ling, Shuiyin Liu, Laura Luzzi and Damien Stehle, "Decoding by embedding: Correct decoding radius and DMT optimality," ISIT 2011.
+- Li-Chia Choo, Cong Ling, and Kat-kit Wong, "Achievable rates for lattice coding over the Gaussian wiretap channel," ICC 2011 Physical Layer Security Workshop.
+- Kezhi Li, Cong Ling and Lu Gan, "Deterministic compressed-sensing matrices: Where Toeplitz meets Golay," IEEE ICASSP 2011, Prague, Czech.
+- Hashi Ning, Cong Ling, and Kin K. Leung, "Relay-aided interference alignment: Feasibility conditions and algorithm," ISIT 2010, Austin, US.
+- Shuiyin Liu, Cong Ling, and Damien Stehle, "Randomized lattice decoding: Bridging the gap between lattice reduction and sphere decoding," ISIT 2010, Austin, US.
+- Cong Ling and Wai Ho Mow, "A unified view of sorting in lattice reduction: From V-BLAST to LLL and beyond," IEEE Inform. Theory Workshop 2009, Taormina, Italy.
+- Kezhi Li, Cong Ling and Lu Gan, "Statistical restricted isometry property of orthogonal symmetric Toeplitz matrices," IEEE Inform. Theory Workshop 2009, Taormina, Italy.
+- Haishi Ning, Cong Ling and Kin Leung, "Active physical-layer network coding for cooperative two-way relay channels," Second IEEE International Workshop on Wireless Network Coding, Rome, Italy, 2009.
+- Su Gao and Cong Ling, "Multi-dimensional nested lattice quantization for Wyner-Ziv coding," ICC 2009, Dresden, Germany.
+- Haishi Ning, Cong Ling and Kin Leung, "Near-optimal relaying strategy for cooperative broadcast channel," ICC 2009, Dresden, Germany.
+- Cong Ling and Wai Ho Mow, "On complex LLL algorithm for digital communications," LLL+25 Conference, Caen, France, 2007.
+- Xiaofu Wu, Cong Ling et al., "Towards understanding weighted bit-flipping decoding," ISIT 2007, Nice, France.
+- Cong Ling and Nick Howgrave-Graham, "Effective LLL reduction for lattice decoding," ISIT 2007, Nice, France.
+- Lu Gan and Cong Ling, "Computation of the dual frame: Forward and backward Greville formulas," IEEE ICASSP 2007.
+- Cong Ling, Lu Gan, and Wai Ho Mow, "A dual-lattice view of V-BLAST detection," IEEE Inform. Theory Workshop, Chengdu, China, 2006.
+- Cong Ling, "Gallager bounds for space-time codes in quasi-static fading channels," IEEE Inform. Theory Workshop, 2006.
+- Cong Ling, "Approximate lattice decoding: Primal versus dual basis reduction," ISIT 2006, Seattle.
+- Cong Ling, "Towards characterizing the performance of approximate lattice decoding in MIMO communications," Int. Symp. Turbo Codes / Int. ITG Conf. Source Channel Coding 2006, Munich, Germany.
+- Cong Ling, W. H. Mow, K. H. Li and A. C. Kot, "Differential lattice decoding in noncoherent MIMO communication," ICC 2005, Seoul, Korea.
+- Cong Ling, K. H. Li and A. C. Kot, "Gallager bounds for space-time codes," IEEE Communication Theory Workshop 2004, Capri, Italy.
+- Cong Ling, K. H. Li and A. C. Kot, "On Decision-Feedback Detection of Nondiagonal Differential Space-Time Modulation in Temporally Correlated Fading Channels," ICC 2003, Anchorage, AL.
+- Cong Ling, K. H. Li and A. C. Kot, "Decision-feedback multiple symbol differential detection of differential space-time modulation in continuously fading channels," ICASSP 2003, Hong Kong, China.
+- Cong Ling and Xiaofu Wu, "Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels," ICC 2002, New York.
+- Xiaofu Wu, Cong Ling and Haige Xiang, "Despreading chip waveform design for coherent delay-locked tracking in DS/SS systems," ICC 2002, New York.
+**---**
 
+### Book/Book Chapter
+- Daniel Valderas, Juan Ignaco Sancho, David Puente, Cong Ling, and Xiaodong Chen, *Ultrawideband Antennas: Design and Applications*, Imperial College Press, 2010.
+- Haishi Ning and Cong Ling, "Network coding in heterogeneous wireless networks," in *Heterogeneous Cellular Networks*, eds Xiaoli Chu and David Lopez Perez, Cambridge University Press, to be published in 2012.


### PR DESCRIPTION
## Summary
- revert publication page to manual version
- add separators between the major sections

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be924f99c832b8b7f2ae27e61926c