### PR TITLE
Move Information Theory page into teaching collection

### DIFF
--- a/_teaching/information-theory.md
+++ b/_teaching/information-theory.md
@@ -1,9 +1,14 @@
 ---
-layout: page
 title: "Information Theory"
+collection: teaching
+type: "Undergraduate Course"
 permalink: /teaching/information-theory/
+venue: "Imperial College London"
+date: 2024-01-01
+location: "London, UK"
 ---
 {% include base_path %}
+
 
 
 ## Syllabus


### PR DESCRIPTION
## Summary
- convert `information-theory.md` page to a teaching collection item
- keep the existing link in `teaching.html`

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c58e8f62c832ba266e5152fb543cd