### PR TITLE
Add missing links for communication systems

### DIFF
--- a/_teaching/communication-systems.md
+++ b/_teaching/communication-systems.md
@@ -1,0 +1,53 @@
+---
+title: "Communication Systems"
+collection: teaching
+type: "Undergraduate Course"
+permalink: /teaching/communication-systems/
+venue: "Imperial College London"
+date: 2024-01-01
+location: "London, UK"
+---
+{% include base_path %}
+
+## Syllabus
+
+What is the course about, and what are the key results; probability and random processes; models for noise in communication channels; representation of band-limited noise; effect of noise in an analog baseband system; effect of noise in AM systems; effect of noise in FM systems; introduction to digital communications systems; performance of digital systems in the presence of noise; introduction to information theory; what does information theory have to say about the performance of communications systems; elements of source coding and channel coding.
+
+## Textbooks
+
+- S. Haykin & M. Moher, *Communication Systems*, 5th ed., International Student Version, Wiley, 2009
+- S. Haykin, *Communication Systems*, 4th ed., Wiley, 2001
+- B.P. Lathi, *Modern Digital and Analog Communication Systems*, 3rd ed., Oxford University Press, 1998
+- J.G. Proakis and M. Salehi, *Communication Systems Engineering*, Prentice-Hall, 1994
+- L.W. Couch II, *Digital and Analog Communication Systems*, 6th ed., Prentice-Hall, 2001
+
+## Lecture Slides
+
+[PDF]({{ base_path }}/files/Com/Comm2_2012.pdf). Also available in Blackboard.
+
+## Problem Sheets
+
+[PDF]({{ base_path }}/files/Com/Problems.pdf). Also available in Blackboard.
+
+## Past Exam Papers
+
+- [2008]({{ base_path }}/files/Com/Comm2-08-Exam.pdf)
+- [2009]({{ base_path }}/files/Com/E2.4Commns209PaperSolns.pdf)
+- [2010]({{ base_path }}/files/Com/E2.4%20Commns%202%20Paper%20Solns%202010.pdf)
+- [2011]({{ base_path }}/files/Com/EE2-4%20Commns%202%20Paper%20Solns%202011.pdf)
+
+## Office Hours
+
+Check your timetable. You can come to ask questions.
+
+## Frequently Asked Questions
+
+* *Is topic "xyz" examinable?* All topics included in the lectures are examinable with the exception of the polynomial representation of cyclic codes.
+* *Do I need to remember long formulas?* In general you are not expected to memorize long complicated formulas. However you will be expected to remember some basic and important formulas such as the Shannon formula.
+* *How many problems will I choose in the exam?* There are no choices any more in the final exam. This is to discourage game playing and selective revision.
+
+
+## Links
+
+- [White noise MP3](http://cantonbecker.com/music/white-noise-sleep-sounds/mp3s.php)
+- [Link to Information Theory and GreenTouch](http://www.greentouch.org/index.php?page=shannons-law-explained)


### PR DESCRIPTION
## Summary
- fix the communication systems page with a Links section

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*
- `bundle install` *(fails: cannot fetch gems)*

------
https://chatgpt.com/codex/tasks/task_e_684c64219a18832b8e67e4cff73f96b7