### PR TITLE
Group teaching posts as current or past

### DIFF
--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -7,16 +7,23 @@ author_profile: true
 
 {% include base_path %}
 
+{% assign current_teaching = site.teaching | where: "status", "current" %}
+{% assign past_teaching = site.teaching | where: "status", "past" %}
+
 <h2>Courses</h2>
 <p>Current:</p>
 <ul>
 <li>Quantum Information and Post-Quantum Cryptography (jointly with Dr <a href="https://www.imperial.ac.uk/people/f.mintert" target="_blank">Florian Mintert</a>)</li>
-<li><a href="{{ "/teaching/information-theory/" | relative_url }}">Information Theory</a></li>
 <li>Probability and Random Processes</li>
+{% for post in current_teaching %}
+<li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+{% endfor %}
 </ul>
 <p>Past:</p>
 <ul>
-<li><a href="http://www.commsp.ee.ic.ac.uk/~cling/Com/Communications.htm">Communication Systems</a></li>
+{% for post in past_teaching %}
+<li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+{% endfor %}
 </ul>
 
 {% for post in site.teaching reversed %}

--- a/_teaching/2014-spring-teaching-1.md
+++ b/_teaching/2014-spring-teaching-1.md
@@ -6,6 +6,7 @@ permalink: /teaching/2014-spring-teaching-1
 venue: "University 1, Department"
 date: 2014-01-01
 location: "City, Country"
+status: past
 ---
 
 This is a description of a teaching experience. You can use markdown like any other post.

--- a/_teaching/2015-spring-teaching-2.md
+++ b/_teaching/2015-spring-teaching-2.md
@@ -6,6 +6,7 @@ permalink: /teaching/2015-spring-teaching-1
 venue: "University 1, Department"
 date: 2015-01-01
 location: "City, Country"
+status: past
 ---
 
 This is a description of a teaching experience. You can use markdown like any other post.

--- a/_teaching/communication-systems.md
+++ b/_teaching/communication-systems.md
@@ -6,6 +6,7 @@ permalink: /teaching/communication-systems/
 venue: "Imperial College London"
 date: 2024-01-01
 location: "London, UK"
+status: past
 ---
 {% include base_path %}
 

--- a/_teaching/information-theory.md
+++ b/_teaching/information-theory.md
@@ -6,6 +6,7 @@ permalink: /teaching/information-theory/
 venue: "Imperial College London"
 date: 2024-01-01
 location: "London, UK"
+status: current
 ---
 {% include base_path %}
 


### PR DESCRIPTION
## Summary
- add `status` front matter to teaching entries
- update teaching page to automatically list courses under current and past categories

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*
- `bundle exec jekyll build` *(fails: jekyll missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c67c433c8832bbb7775e35fc78be0