### PR TITLE
Add Cong Ling photo to biography page

### DIFF
--- a/_pages/biography.md
+++ b/_pages/biography.md
@@ -9,6 +9,8 @@ author_profile: true
 
 **Cong Ling** (凌聪)  
 
+![Cong Ling]({{ base_path }}/images/CongLing.jpg){: width="300"}
+
 Cong Ling is currently a Professor in the Electrical and Electronic Engineering Department at Imperial College London. He is a member of the [Academic Centre of Excellence in Cyber Security Research](http://www3.imperial.ac.uk/securesoftwaresystems) at Imperial College and an affiliated member of the [Institute of Security Science and Technology](http://www3.imperial.ac.uk/securityinstitute) of Imperial College.
 
 Dr. Ling has been an Associate Editor (in multiterminal communications and lattice coding) of IEEE Transactions on Communications, and an Associate Editor of IEEE Transactions on Vehicular Technology. He is a member of IEEE.


### PR DESCRIPTION
## Summary
- embed Cong Ling's photograph on the biography page

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca9fe9dcc832bae21029600dd59e0